### PR TITLE
Fix issue #112, #113

### DIFF
--- a/csharp/src/SeedLang/Ast/Expressions.cs
+++ b/csharp/src/SeedLang/Ast/Expressions.cs
@@ -63,15 +63,6 @@ namespace SeedLang.Ast {
       return new NumberConstantExpression(value, range);
     }
 
-    // The factory method to create a number constant expression from a string.
-    internal static NumberConstantExpression NumberConstant(string value, Range range) {
-      try {
-        return NumberConstant(double.Parse(value), range);
-      } catch (System.Exception) {
-        return NumberConstant(0, range);
-      }
-    }
-
     // The factory method to create a string constant expression.
     internal static StringConstantExpression StringConstant(string value, Range range) {
       return new StringConstantExpression(value, range);

--- a/csharp/src/SeedLang/Runtime/ValueHelper.cs
+++ b/csharp/src/SeedLang/Runtime/ValueHelper.cs
@@ -120,7 +120,7 @@ namespace SeedLang.Runtime {
     internal static void CheckOverflow(double value, Range range = null) {
       // TODO: do we need separate NaN as another runtime error?
       if (double.IsInfinity(value) || double.IsNaN(value)) {
-        throw new DiagnosticException(SystemReporters.SeedAst, Severity.Error, "", range,
+        throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Error, "", range,
                                       Message.RuntimeErrorOverflow);
       }
     }

--- a/csharp/src/SeedLang/X/BaseParser.cs
+++ b/csharp/src/SeedLang/X/BaseParser.cs
@@ -52,8 +52,14 @@ namespace SeedLang.X {
         node = null;
         return false;
       }
-      node = visitor.Visit(program);
-      return true;
+      try {
+        node = visitor.Visit(program);
+        return true;
+      } catch (DiagnosticException e) {
+        collection.Report(e.Diagnostic);
+        node = null;
+        return false;
+      }
     }
 
     protected abstract Lexer MakeLexer(ICharStream stream);

--- a/csharp/src/SeedLang/X/VisitorHelper.cs
+++ b/csharp/src/SeedLang/X/VisitorHelper.cs
@@ -184,7 +184,8 @@ namespace SeedLang.X {
     // Builds a number constant expresssion.
     internal NumberConstantExpression BuildNumberConstant(IToken token) {
       TextRange range = HandleConstantOrVariableExpression(token, SyntaxType.Number);
-      return Expression.NumberConstant(token.Text, range);
+      double value = double.Parse(token.Text);
+      return Expression.NumberConstant(value, range);
     }
 
     // Builds a string constant expresssion.

--- a/csharp/tests/SeedLang.Tests/X/SeedCalcTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedCalcTests.cs
@@ -46,12 +46,28 @@ namespace SeedLang.X.Tests {
                 "  [Ln 1, Col 0 - Ln 1, Col 0] NumberConstantExpression (0)",
 
                 "Number [Ln 1, Col 0 - Ln 1, Col 0]")]
+
+    [InlineData("0\n",
+
+                "[Ln 1, Col 0 - Ln 1, Col 0] ExpressionStatement\n" +
+                "  [Ln 1, Col 0 - Ln 1, Col 0] NumberConstantExpression (0)",
+
+                "Number [Ln 1, Col 0 - Ln 1, Col 0]")]
+
+    [InlineData("0\n\n",
+
+                "[Ln 1, Col 0 - Ln 1, Col 0] ExpressionStatement\n" +
+                "  [Ln 1, Col 0 - Ln 1, Col 0] NumberConstantExpression (0)",
+
+                "Number [Ln 1, Col 0 - Ln 1, Col 0]")]
+
     [InlineData("0.",
 
                 "[Ln 1, Col 0 - Ln 1, Col 1] ExpressionStatement\n" +
                 "  [Ln 1, Col 0 - Ln 1, Col 1] NumberConstantExpression (0)",
 
                 "Number [Ln 1, Col 0 - Ln 1, Col 1]")]
+
     [InlineData(".0",
 
                 "[Ln 1, Col 0 - Ln 1, Col 1] ExpressionStatement\n" +
@@ -294,7 +310,7 @@ namespace SeedLang.X.Tests {
 
     [InlineData(".3.",
                 new string[] {
-                  "SyntaxErrorUnwantedToken '.' <EOF>",
+                  "SyntaxErrorUnwantedToken '.' {<EOF>, NEWLINE}",
                 },
 
                 "Number [Ln 1, Col 0 - Ln 1, Col 1]," +
@@ -302,7 +318,7 @@ namespace SeedLang.X.Tests {
 
     [InlineData(".3@",
                 new string[] {
-                  "SyntaxErrorUnwantedToken '@' <EOF>",
+                  "SyntaxErrorUnwantedToken '@' {<EOF>, NEWLINE}",
                 },
 
                 "Number [Ln 1, Col 0 - Ln 1, Col 1]," +

--- a/grammars/SeedCalc.g4
+++ b/grammars/SeedCalc.g4
@@ -27,7 +27,7 @@ grammar SeedCalc;
  * Parser rules
  */
 
-expressionStatement: expression EOF;
+expressionStatement: expression NEWLINE* EOF;
 
 expression: sum;
 
@@ -66,6 +66,8 @@ INTEGER: DECIMAL_INTEGER;
 DECIMAL_INTEGER: NON_ZERO_DIGIT DIGIT* | '0'+;
 
 FLOAT_NUMBER: POINT_FLOAT | EXPONENT_FLOAT;
+
+NEWLINE: ('\r'? '\n' | '\r' | '\f') SPACES?;
 
 SKIP_: SPACES -> skip;
 


### PR DESCRIPTION
- Fix #112: Handles SeedCalc expressions with newlines.
- Fix #113: Checks overflow runtime errors for number constant expressions.