### PR TITLE
Update version number for a formal NuGet release

### DIFF
--- a/README.nuget.md
+++ b/README.nuget.md
@@ -1,0 +1,7 @@
+# SeedLang
+
+SeedLang is a visualizable low-code programming environment that focuses on
+educational purposes.
+
+See [SeedLang's GitHub page](https://github.com/SeedV/SeedLang) for more
+details.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,7 +14,7 @@ To publish a pre-release build of the NuGet package:
 cd csharp
 dotnet clean
 rm src/SeedLang/bin/Release/SeedLang.*.nupkg
-dotnet pack -c Release -p:ReleaseTag=preview
+dotnet pack src/SeedLang -c Release -p:ReleaseTag=preview
 dotnet nuget push src/SeedLang/bin/Release/SeedLang.*.nupkg --api-key <apikey> \
   --source https://api.nuget.org/v3/index.json
 ```
@@ -41,22 +41,26 @@ To publish a formal release build of the NuGet package:
 Manually assign a new version number `<major>.<minor>.<patch>` to the release
 build.
 
-Create a release branch and prepare a PR to update the `VersionPrefix` property
-accordingly at:
+Prepare a versioning PR to update the `VersionPrefix` property in the following
+two project files:
 
 * [SeedLang.csproj](./csharp/src/SeedLang/SeedLang.csproj)
 * [SeedLang.Shell.csproj](./csharp/src/SeedLang.Shell/SeedLang.Shell.csproj)
 
-Get the release PR approved by the dev team and merged into main branch. Tag the
-main branch with a release tag like `v<major>.<minor>.<patch>`.
+Get the versioning PR approved by the dev team and merged into the main branch.
 
-Build and publish the package to NuGet:
+In GitHub, [create a new release for
+SeedLang](https://github.com/SeedV/SeedLang/releases/new) and assign a release
+tag to the main branch. The release tag is typically formatted as
+`v<major>.<minor>.<patch>`.
+
+Build the SeedLang package and publish it to NuGet:
 
 ```shell
 cd csharp
 dotnet clean
 rm src/SeedLang/bin/Release/SeedLang.*.nupkg
-dotnet pack -c Release -p:ReleaseTag=release
+dotnet pack src/SeedLang -c Release -p:ReleaseTag=release
 dotnet nuget push src/SeedLang/bin/Release/SeedLang.*.nupkg --api-key <apikey> \
  --source https://api.nuget.org/v3/index.json
 ```

--- a/csharp/src/SeedLang.Shell/SeedLang.Shell.csproj
+++ b/csharp/src/SeedLang.Shell/SeedLang.Shell.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <PackageId>SeedLang.Shell</PackageId>
     <ReleaseTag>preview</ReleaseTag>
-    <VersionPrefix>0.1.2</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <Version Condition="'$(ReleaseTag)' != 'release'">$(VersionPrefix)-$(ReleaseTag)$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</Version>
     <Version Condition="'$(ReleaseTag)' == 'release'">$(VersionPrefix)+$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</Version>

--- a/csharp/src/SeedLang/SeedLang.csproj
+++ b/csharp/src/SeedLang/SeedLang.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <PackageId>SeedLang</PackageId>
     <ReleaseTag>preview</ReleaseTag>
-    <VersionPrefix>0.1.2</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <Version Condition="'$(ReleaseTag)' != 'release'">$(VersionPrefix)-$(ReleaseTag)$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</Version>
     <Version Condition="'$(ReleaseTag)' == 'release'">$(VersionPrefix)+$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</Version>
@@ -15,7 +15,13 @@
     <RepositoryUrl>https://github.com/SeedV/SeedLang</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <Description>SeedLang is a visualizable low-code programming environment that focuses on educational purposes.</Description>
+    <PackageReadmeFile>README.nuget.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+    <None Include="..\..\..\README.nuget.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />


### PR DESCRIPTION
* Update version number to 0.2.0
* Add a short README for NuGet release
* Update the process described in RELEASING.md

See https://www.nuget.org/packages/SeedLang for the preview release based on this PR.

I think SeedLang is ready for a formal "minor" release - since the SeedCalc language is almost 100% ready and will be formally used by the first release of SeedCalc. We will create a formal release entry both on GitHub and on NuGet.

We can add a very short intro in GitHub's release notes to clarify that only SeedCalc is ready while other languages like SeedPython are still in progress.