### PR TITLE
Add a GitHub CI action to upload benchmark results to wiki

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,7 +2,7 @@ name: Benchmark
 
 on:
   push:
-    branches: [bugfix_79]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,35 @@
+name: Benchmark
+
+on:
+  push:
+    branches: [bugfix_79]
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+      - name: Restore dependencies
+        working-directory: ./csharp
+        run: dotnet restore
+      - name: Build
+        working-directory: ./csharp
+        run: dotnet build --no-restore
+      - name: Benchmark
+        working-directory: ./csharp
+        run: dotnet run -c Release --project benchmark/SeedLang.Benchmark
+      - name: Check out wiki
+        uses: actions/checkout@v2
+        with:
+          repository: "SeedV/SeedLang.wiki"
+          ref: "master"
+          path: "SeedLang.wiki"
+      - name: Update benchmark.md if needed
+        run: ./benchmark/SeedLang.Benchmark/update_wiki.sh $GITHUB_WORKSPACE/SeedLang.wiki
+        working-directory: ./csharp

--- a/csharp/benchmark/SeedLang.Benchmark/update_wiki.sh
+++ b/csharp/benchmark/SeedLang.Benchmark/update_wiki.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Copyright 2021-2022 The SeedV Lab.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+markdown_name="$1/Benchmark.md"
+results_path=./BenchmarkDotNet.Artifacts/results
+old_md5=$(md5sum "${markdown_name}")
+
+rm -f "${markdown_name}"
+
+{
+  cat <<END
+# Benchmark
+
+## Fibonacci
+
+END
+
+  cat ${results_path}/SeedLang.Benchmark.FibBenchmark-report-github.md
+
+  cat <<END
+
+## Sum
+
+END
+
+  cat ${results_path}/SeedLang.Benchmark.SumBenchmark-report-github.md
+} >>"${markdown_name}"
+
+new_md5=$(md5sum "${markdown_name}")
+
+echo "Old md5 sum: ${old_md5}; New md5 sum: ${new_md5}"
+
+if [ "${old_md5}" != "${new_md5}" ]; then
+  cd "$1" || exit
+  git config --global user.email "wyw@seedv.com"
+  git config --global user.name "codingpotato"
+  git add Benchmark.md
+  git commit -m "Update Benchmark.ms at $(date)"
+  git push origin master
+  echo "Benchmark.mk updated."
+fi

--- a/csharp/benchmark/SeedLang.Benchmark/update_wiki.sh
+++ b/csharp/benchmark/SeedLang.Benchmark/update_wiki.sh
@@ -24,6 +24,14 @@ rm -f "${markdown_name}"
   cat <<END
 # Benchmark
 
+## Fibonacci
+
+END
+
+  cat ${results_path}/SeedLang.Benchmark.FibBenchmark-report-github.md
+
+  cat <<END
+
 ## Sum
 
 END

--- a/csharp/benchmark/SeedLang.Benchmark/update_wiki.sh
+++ b/csharp/benchmark/SeedLang.Benchmark/update_wiki.sh
@@ -15,6 +15,7 @@
 
 markdown_name="$1/Benchmark.md"
 results_path=./BenchmarkDotNet.Artifacts/results
+
 old_md5=$(md5sum "${markdown_name}")
 
 rm -f "${markdown_name}"
@@ -22,14 +23,6 @@ rm -f "${markdown_name}"
 {
   cat <<END
 # Benchmark
-
-## Fibonacci
-
-END
-
-  cat ${results_path}/SeedLang.Benchmark.FibBenchmark-report-github.md
-
-  cat <<END
 
 ## Sum
 


### PR DESCRIPTION
Fix #79 

Only do benchmarks and upload the results to wiki when a PR is merge and push to the main branch, because the benchmark process is very slow.