### PR TITLE
Implement attribute statements for build-in value types

### DIFF
--- a/csharp/src/SeedLang/Ast/Expressions.cs
+++ b/csharp/src/SeedLang/Ast/Expressions.cs
@@ -77,8 +77,15 @@ namespace SeedLang.Ast {
       return new SubscriptExpression(expr, index, range);
     }
 
+    // The factory method to create a call expression.
     internal static CallExpression Call(Expression func, Expression[] arguments, Range range) {
       return new CallExpression(func, arguments, range);
+    }
+
+    // The factory method to create an attribute expression.
+    internal static AttributeExpression Attribute(Expression expr, IdentifierExpression attr,
+                                                  Range range) {
+      return new AttributeExpression(expr, attr, range);
     }
 
     internal Expression(Range range) : base(range) { }
@@ -194,6 +201,17 @@ namespace SeedLang.Ast {
     internal CallExpression(Expression func, Expression[] arguments, Range range) : base(range) {
       Func = func;
       Arguments = arguments;
+    }
+  }
+
+  internal class AttributeExpression : Expression {
+    public Expression Value { get; }
+    public IdentifierExpression Attr { get; }
+
+    internal AttributeExpression(Expression value, IdentifierExpression attr, Range range) :
+        base(range) {
+      Value = value;
+      Attr = attr;
     }
   }
 }

--- a/csharp/src/SeedLang/Interpreter/Compiler.cs
+++ b/csharp/src/SeedLang/Interpreter/Compiler.cs
@@ -144,7 +144,7 @@ namespace SeedLang.Interpreter {
         }
         Visit(expr);
       }
-      _chunk.Emit(Opcode.NEWLIST, target, first.Value, (uint)list.Exprs.Length, list.Range);
+      _chunk.Emit(Opcode.NEWLIST, target, first ?? 0, (uint)list.Exprs.Length, list.Range);
       _variableResolver.EndExpressionScope();
     }
 

--- a/csharp/src/SeedLang/Runtime/NativeFunctions.cs
+++ b/csharp/src/SeedLang/Runtime/NativeFunctions.cs
@@ -27,6 +27,8 @@ namespace SeedLang.Runtime {
     public const string Range = "range";
 
     public static NativeFunction[] Funcs = new NativeFunction[] {
+      // Appends a value to a list. The first argument is the list, the second argument is the
+      // value to be appended to the list.
       new NativeFunction(Append, (Value[] args, int offset, int length) => {
         if (length != 2) {
           throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Fatal, "", null,

--- a/csharp/src/SeedLang/Runtime/NativeFunctions.cs
+++ b/csharp/src/SeedLang/Runtime/NativeFunctions.cs
@@ -21,11 +21,25 @@ namespace SeedLang.Runtime {
 
   // The static class to define all the build-in native functions.
   internal static class NativeFunctions {
+    public const string Append = "append";
     public const string Len = "len";
     public const string List = "list";
     public const string Range = "range";
 
     public static NativeFunction[] Funcs = new NativeFunction[] {
+      new NativeFunction(Append, (Value[] args, int offset, int length) => {
+        if (length != 2) {
+          throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Fatal, "", null,
+                                        Message.RuntimeErrorIncorrectArgsCount);
+        }
+        Value value = args[offset];
+        if (value.IsList) {
+          List<Value> list = value.AsList();
+          list.Add(args[offset + 1]);
+        }
+        return new Value(true);
+      }),
+
       new NativeFunction(Len, (Value[] args, int offset, int length) => {
         if (length != 1) {
           throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Fatal, "", null,

--- a/csharp/src/SeedLang/Runtime/NativeFunctions.cs
+++ b/csharp/src/SeedLang/Runtime/NativeFunctions.cs
@@ -39,7 +39,7 @@ namespace SeedLang.Runtime {
           List<Value> list = value.AsList();
           list.Add(args[offset + 1]);
         }
-        return new Value(true);
+        return new Value();
       }),
 
       new NativeFunction(Len, (Value[] args, int offset, int length) => {

--- a/csharp/src/SeedLang/X/SeedBlockInlineText.cs
+++ b/csharp/src/SeedLang/X/SeedBlockInlineText.cs
@@ -40,6 +40,7 @@ namespace SeedLang.X {
       { SeedBlockInlineTextParser.GREATER, SyntaxType.Operator},
       { SeedBlockInlineTextParser.OPEN_PAREN, SyntaxType.Parenthesis},
       { SeedBlockInlineTextParser.CLOSE_PAREN, SyntaxType.Parenthesis},
+      { SeedBlockInlineTextParser.DOT, SyntaxType.Symbol},
       { SeedBlockInlineTextParser.UNKNOWN_CHAR, SyntaxType.Unknown },
     };
 

--- a/csharp/src/SeedLang/X/SeedPythonVisitor.cs
+++ b/csharp/src/SeedLang/X/SeedPythonVisitor.cs
@@ -236,6 +236,11 @@ namespace SeedLang.X {
                                     context.expression(), context.CLOSE_BRACK().Symbol, this);
     }
 
+    public override AstNode VisitAttribute([NotNull] SeedPythonParser.AttributeContext context) {
+      return _helper.BuildAttribute(context.primary(), context.DOT().Symbol, context.identifier(),
+                                    this);
+    }
+
     public override AstNode VisitTrue([NotNull] SeedPythonParser.TrueContext context) {
       return _helper.BuildBooleanConstant(context.TRUE().Symbol, true);
     }

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
@@ -544,6 +544,21 @@ namespace SeedLang.Interpreter.Tests {
     }
 
     [Fact]
+    public void TestCompileEmptyList() {
+      var list = AstHelper.ExpressionStmt(AstHelper.List());
+      var compiler = new Compiler();
+      var env = new GlobalEnvironment(NativeFunctions.Funcs);
+      var func = compiler.Compile(list, env);
+      string expected = (
+          $"Function <main>\n" +
+          $"  1    NEWLIST   0 0 0                                {AstHelper.TextRange}\n" +
+          $"  2    EVAL      0                                    {AstHelper.TextRange}\n" +
+          $"  3    RETURN    0                                    \n"
+      ).Replace("\n", Environment.NewLine);
+      Assert.Equal(expected, new Disassembler(func).ToString());
+    }
+
+    [Fact]
     public void TestCompileList() {
       var list = AstHelper.ExpressionStmt(AstHelper.List(AstHelper.NumberConstant(1),
                                                          AstHelper.NumberConstant(2),

--- a/csharp/tests/SeedLang.Tests/Runtime/ExecutorPythonTests.cs
+++ b/csharp/tests/SeedLang.Tests/Runtime/ExecutorPythonTests.cs
@@ -127,6 +127,14 @@ array
 ",
 
     "[11, 12, 22, 25, 34, 64, 90]")]
+
+    [InlineData(@"array = []
+for i in range(5):
+  array.append(i)
+array
+",
+
+    "[0, 1, 2, 3, 4]")]
     public void TestExecutor(string source, string result) {
       TestWithRunType(source, result, RunType.Ast);
       TestWithRunType(source, result, RunType.Bytecode);

--- a/csharp/tests/SeedLang.Tests/Runtime/ExecutorPythonTests.cs
+++ b/csharp/tests/SeedLang.Tests/Runtime/ExecutorPythonTests.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using SeedLang.Common;
 using Xunit;
 
 namespace SeedLang.Runtime.Tests {

--- a/csharp/tests/SeedLang.Tests/X/SeedBlockInlineTextTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedBlockInlineTextTests.cs
@@ -189,12 +189,12 @@ namespace SeedLang.X.Tests {
 
     [InlineData(".",
 
-                "Unknown [Ln 1, Col 0 - Ln 1, Col 0]")]
+                "Symbol [Ln 1, Col 0 - Ln 1, Col 0]")]
 
     [InlineData(".3.",
 
                 "Number [Ln 1, Col 0 - Ln 1, Col 1]," +
-                "Unknown [Ln 1, Col 2 - Ln 1, Col 2]")]
+                "Symbol [Ln 1, Col 2 - Ln 1, Col 2]")]
 
     [InlineData(".3@",
 

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonExpressionTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonExpressionTests.cs
@@ -279,6 +279,21 @@ namespace SeedLang.X.Tests {
                 "Symbol [Ln 1, Col 5 - Ln 1, Col 5]," +
                 "Number [Ln 1, Col 7 - Ln 1, Col 7]," +
                 "Parenthesis [Ln 1, Col 8 - Ln 1, Col 8]")]
+
+    [InlineData("a.append(1)",
+
+                "[Ln 1, Col 2 - Ln 1, Col 10] ExpressionStatement\n" +
+                "  [Ln 1, Col 2 - Ln 1, Col 10] CallExpression\n" +
+                "    [Ln 1, Col 2 - Ln 1, Col 7] IdentifierExpression (append)\n" +
+                "    [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (a)\n" +
+                "    [Ln 1, Col 9 - Ln 1, Col 9] NumberConstantExpression (1)",
+
+                "Variable [Ln 1, Col 0 - Ln 1, Col 0]," +
+                "Symbol [Ln 1, Col 1 - Ln 1, Col 1]," +
+                "Variable [Ln 1, Col 2 - Ln 1, Col 7]," +
+                "Parenthesis [Ln 1, Col 8 - Ln 1, Col 8]," +
+                "Number [Ln 1, Col 9 - Ln 1, Col 9]," +
+                "Parenthesis [Ln 1, Col 10 - Ln 1, Col 10]")]
     public void TestPythonParser(string input, string expectedAst, string expectedTokens) {
       Assert.True(_parser.Parse(input, "", _collection, out AstNode node,
                                 out IReadOnlyList<SyntaxToken> tokens));

--- a/grammars/Common.g4
+++ b/grammars/Common.g4
@@ -63,8 +63,11 @@ factor:
   | SUBTRACT factor      # negative
   | primary POWER factor # power
   | primary              # primary_as_factor;
+
+// There is duplicate for subscript and subscript_target, because ANTLR doesn't support left recursion.
 primary:
-  primary OPEN_BRACK expression CLOSE_BRACK   # subscript
+  primary DOT identifier                      # attribute
+  | primary OPEN_BRACK expression CLOSE_BRACK # subscript
   | primary OPEN_PAREN arguments? CLOSE_PAREN # call
   | atom                                      # atom_as_primary;
 atom:
@@ -119,6 +122,7 @@ CLOSE_BRACK: ']';
 OPEN_BRACE: '{';
 CLOSE_BRACE: '}';
 
+DOT: '.';
 COMMA: ',';
 
 NAME: ID_START ID_CONTINUE*;
@@ -145,13 +149,13 @@ UNKNOWN_CHAR: .;
 
 fragment POINT_FLOAT:
   INT_PART? FRACTION
-  | INT_PART '.';
+  | INT_PART DOT;
 
 fragment EXPONENT_FLOAT: (INT_PART | POINT_FLOAT) EXPONENT;
 
 fragment INT_PART: DIGIT+;
 
-fragment FRACTION: '.' DIGIT+;
+fragment FRACTION: DOT DIGIT+;
 
 fragment EXPONENT: [eE] [+-]? DIGIT+;
 

--- a/grammars/Common.g4
+++ b/grammars/Common.g4
@@ -64,7 +64,6 @@ factor:
   | primary POWER factor # power
   | primary              # primary_as_factor;
 
-// There is duplicate for subscript and subscript_target, because ANTLR doesn't support left recursion.
 primary:
   primary DOT identifier                      # attribute
   | primary OPEN_BRACK expression CLOSE_BRACK # subscript


### PR DESCRIPTION
Following code can be run by SeedVM:

```python
array = []
for i in range(5):
  array.append(i)


array
```