### PR TITLE
Refactor SeedLang.Shell to show line numbers of source code

### DIFF
--- a/csharp/src/SeedLang.Shell/Program.cs
+++ b/csharp/src/SeedLang.Shell/Program.cs
@@ -32,7 +32,7 @@ namespace SeedLang.Shell {
 
       [Option('v', "visualizers", Required = false,
               Default = new VisualizerType[] { VisualizerType.Eval },
-              HelpText = "The Visualizers to be enabled.")]
+              HelpText = "The Visualizers to be enabled. Use All to enable all visualizers.")]
       public IEnumerable<VisualizerType> VisualizerTypes { get; set; }
 
       [Option('f', "file", Required = false, Default = null,
@@ -77,11 +77,21 @@ namespace SeedLang.Shell {
         Console.WriteLine($"Read file error: {ex}.");
         return;
       }
+      var syntaxTokens = Executor.ParseSyntaxTokens(source.Source, "", language);
+      source.WriteSourceWithSyntaxTokens(syntaxTokens);
+
+      Console.WriteLine();
+      Console.WriteLine("---------- Run ----------");
       var visualizerManager = new VisualizerManager(source, visualizerTypes);
       var executor = new Executor();
       visualizerManager.RegisterToExecutor(executor);
       var collection = new DiagnosticCollection();
-      executor.Run(source.Source, "", language, runType, collection);
+
+      string result = executor.Run(source.Source, "", language, runType, collection);
+      if (!(result is null)) {
+        Console.WriteLine(result);
+      }
+
       foreach (var diagnostic in collection.Diagnostics) {
         if (diagnostic.Range is TextRange range) {
           source.WriteSourceWithHighlight(range);

--- a/csharp/src/SeedLang.Shell/Repl.cs
+++ b/csharp/src/SeedLang.Shell/Repl.cs
@@ -46,12 +46,15 @@ namespace SeedLang.Shell {
         _source.WriteSourceWithSyntaxTokens(syntaxTokens);
         Console.WriteLine("---------- Run ----------");
         var collection = new DiagnosticCollection();
-        executor.Run(_source.Source, "", _language, _runType, collection);
+        string result = executor.Run(_source.Source, "", _language, _runType, collection);
+        if (!(result is null)) {
+          Console.WriteLine(result);
+        }
         foreach (var diagnostic in collection.Diagnostics) {
           if (diagnostic.Range is TextRange range) {
             _source.WriteSourceWithHighlight(range);
           }
-          Console.WriteLine($": {diagnostic}");
+          Console.WriteLine($"{diagnostic}");
         }
       }
       _visualizerManager.UnregisterFromExecutor(executor);

--- a/csharp/src/SeedLang.Shell/SourceCode.cs
+++ b/csharp/src/SeedLang.Shell/SourceCode.cs
@@ -14,73 +14,92 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using SeedLang.Common;
 
 namespace SeedLang.Shell {
   // A class to handle source code input and output.
   internal class SourceCode {
-    public string Source { get; private set; } = "";
+    public string Source => string.Join(null, _lines);
 
-    // The starting index of each line in source code.
-    private readonly List<int> _lineStarts = new List<int>() { 0 };
+    private readonly List<string> _lines = new List<string>();
 
     internal void AddLine(string line) {
-      Source += line + Environment.NewLine;
-      _lineStarts.Add(Source.Length);
+      _lines.Add(line + Environment.NewLine);
     }
 
     internal void Reset() {
-      Source = "";
-      _lineStarts.Clear();
-      _lineStarts.Add(0);
+      _lines.Clear();
     }
 
     internal void WriteSourceWithHighlight(TextRange range) {
-      var first = new TextPosition(1, 0);
-      if (range.Start.CompareTo(first) > 0) {
-        var r = new TextRange(first, new TextPosition(range.Start.Line, range.Start.Column - 1));
-        Console.Write(SourceOfRange(r));
-      }
-      Console.BackgroundColor = ConsoleColor.DarkCyan;
-      Console.ForegroundColor = ConsoleColor.Black;
-      Console.Write(SourceOfRange(range));
-      Console.ResetColor();
-      int startIndex = _lineStarts[range.End.Line - 1] + range.End.Column + 1;
-      if (startIndex < Source.Length) {
-        Console.Write(Source.Substring(startIndex));
+      int lineId = range.Start.Line;
+      while (lineId <= range.End.Line && lineId > 0 && lineId <= _lines.Count) {
+        Console.Write($"{lineId,-5} ");
+        string line = _lines[lineId - 1];
+        if (Intersect(lineId, range) is (int start, int end)) {
+          Console.Write(line.Substring(0, start));
+          if (line.Substring(start) != Environment.NewLine) {
+            Console.BackgroundColor = ConsoleColor.DarkCyan;
+            Console.ForegroundColor = ConsoleColor.Black;
+          }
+          Console.Write(line.Substring(start, end - start + 1));
+          Console.ResetColor();
+          Console.Write(line.Substring(end + 1));
+        } else {
+          Console.Write(line);
+        }
+        lineId++;
       }
     }
 
     internal void WriteSourceWithSyntaxTokens(IReadOnlyList<SyntaxToken> syntaxTokens) {
       Console.ResetColor();
       Console.WriteLine("---------- Source ----------");
-      var currentPos = new TextPosition(1, 0);
-      foreach (SyntaxToken token in syntaxTokens) {
-        if (token.Range.Start.CompareTo(currentPos) > 0) {
-          var endPos = new TextPosition(token.Range.Start.Line, token.Range.Start.Column - 1);
-          Console.Write(SourceOfRange(new TextRange(currentPos, endPos)));
+      int tokenIndex = 0;
+      for (int lineId = 1; lineId <= _lines.Count; lineId++) {
+        WriteLineWithSyntaxTokens(lineId, syntaxTokens, ref tokenIndex);
+      }
+    }
+
+    private void WriteLineWithSyntaxTokens(int lineId, IReadOnlyList<SyntaxToken> syntaxTokens,
+                                           ref int tokenIndex) {
+      int column = 0;
+      Console.Write($"{lineId,-5} ");
+      string line = _lines[lineId - 1];
+      while (column < line.Length && tokenIndex < syntaxTokens.Count &&
+             syntaxTokens[tokenIndex].Range.Start.Line <= lineId) {
+        SyntaxToken token = syntaxTokens[tokenIndex];
+        if (token.Range.Start.Column > column) {
+          Console.Write(line.Substring(column, token.Range.Start.Column - column));
         }
         if (Theme.SyntaxToThemeInfoMap.ContainsKey(token.Type)) {
           Console.ForegroundColor = Theme.SyntaxToThemeInfoMap[token.Type].ForegroundColor;
         }
-        Console.Write(SourceOfRange(token.Range));
+        Console.Write(Substring(line, token.Range.Start.Column, token.Range.End.Column));
         Console.ResetColor();
-        currentPos = new TextPosition(token.Range.End.Line, token.Range.End.Column + 1);
+        column = token.Range.End.Line <= lineId ? token.Range.End.Column + 1 : line.Length;
+        if (token.Range.End.Line <= lineId) {
+          tokenIndex++;
+        }
       }
-      Console.Write(Source.Substring(_lineStarts[currentPos.Line - 1] + currentPos.Column));
-      Console.WriteLine();
+      Console.Write(line.Substring(column));
     }
 
-    private string SourceOfRange(TextRange range) {
-      Debug.Assert(range.Start.Line <= range.End.Line);
-      int startIndex = _lineStarts[range.Start.Line - 1] + range.Start.Column;
-      int endIndex = _lineStarts[range.End.Line - 1] + range.End.Column;
-      if (startIndex >= Source.Length) {
-        return "";
+    private static string Substring(string line, int columnStart, int columnEnd) {
+      return line.Substring(Math.Max(columnStart, 0),
+                            Math.Min(line.Length, columnEnd + 1) - columnStart);
+    }
+
+    private (int, int)? Intersect(int lineId, TextRange range) {
+      if (range.Start.Line > lineId || range.End.Line < lineId) {
+        return null;
       }
-      int length = Math.Min(endIndex, Source.Length - 1) - startIndex + 1;
-      return Source.Substring(startIndex, length);
+      bool isStartLine = lineId == range.Start.Line;
+      bool isEndLine = lineId == range.End.Line;
+      int lineEnd = _lines[lineId - 1].Length - 1;
+      int start = isStartLine ? Math.Min(Math.Max(0, range.Start.Column), lineEnd) : 0;
+      int end = isEndLine ? Math.Min(Math.Max(0, range.End.Column), lineEnd) : lineEnd;
+      return (start, end);
     }
   }
 }

--- a/csharp/src/SeedLang.Shell/Theme.cs
+++ b/csharp/src/SeedLang.Shell/Theme.cs
@@ -28,9 +28,33 @@ namespace SeedLang.Shell {
     public static IReadOnlyDictionary<SyntaxType, ThemeInfo> SyntaxToThemeInfoMap =
         new Dictionary<SyntaxType, ThemeInfo> {
           {
+            SyntaxType.Boolean,
+            new ThemeInfo {
+              ForegroundColor = ConsoleColor.Yellow,
+            }
+          },
+          {
+            SyntaxType.Bracket,
+            new ThemeInfo {
+              ForegroundColor = ConsoleColor.Gray,
+            }
+          },
+          {
+            SyntaxType.Function,
+            new ThemeInfo {
+              ForegroundColor = ConsoleColor.DarkBlue,
+            }
+          },
+          {
             SyntaxType.Keyword,
             new ThemeInfo {
               ForegroundColor = ConsoleColor.Magenta,
+            }
+          },
+          {
+            SyntaxType.None,
+            new ThemeInfo {
+              ForegroundColor = ConsoleColor.DarkYellow,
             }
           },
           {
@@ -43,6 +67,18 @@ namespace SeedLang.Shell {
             SyntaxType.Operator,
             new ThemeInfo {
               ForegroundColor = ConsoleColor.Blue,
+            }
+          },
+          {
+            SyntaxType.Parameter,
+            new ThemeInfo {
+              ForegroundColor = ConsoleColor.Blue,
+            }
+          },
+          {
+            SyntaxType.Parenthesis,
+            new ThemeInfo {
+              ForegroundColor = ConsoleColor.Gray,
             }
           },
           {

--- a/csharp/src/SeedLang/Interpreter/Compiler.cs
+++ b/csharp/src/SeedLang/Interpreter/Compiler.cs
@@ -110,8 +110,8 @@ namespace SeedLang.Interpreter {
             break;
         }
       } else {
-        throw new DiagnosticException(SystemReporters.SeedInterpreter, Severity.Fatal, "", null,
-                                      Message.RuntimeErrorVariableNotDefined);
+        throw new DiagnosticException(SystemReporters.SeedInterpreter, Severity.Fatal, "",
+                                      identifier.Range, Message.RuntimeErrorVariableNotDefined);
       }
     }
 

--- a/csharp/src/SeedLang/Interpreter/VM.cs
+++ b/csharp/src/SeedLang/Interpreter/VM.cs
@@ -151,8 +151,9 @@ namespace SeedLang.Interpreter {
               break;
             case Opcode.RETURN:
               // TODO: only support one return value now.
-              if (instr.B > 0 && baseRegister > 0) {
-                _stack[baseRegister - 1] = _stack[baseRegister + instr.A];
+              if (baseRegister > 0) {
+                uint returnRegister = baseRegister - 1;
+                _stack[returnRegister] = instr.B > 0 ? _stack[baseRegister + instr.A] : new Value();
               }
               _callStack.PopFunc();
               if (!_callStack.IsEmpty) {

--- a/csharp/src/SeedLang/Runtime/RunType.cs
+++ b/csharp/src/SeedLang/Runtime/RunType.cs
@@ -15,9 +15,13 @@
 namespace SeedLang.Runtime {
   // The running type of SeedBlock and SeedX source code.
   public enum RunType {
-    // Parses the source code into an AST tree, and runs it by traversing the AST tree.
+    // Parses source code into an AST tree, and runs it by traversing the AST tree.
     Ast,
-    // Parses and compiles the source code into bytecode, and runs it in a VM.
+    // Parses and compiles source code into bytecode, and runs it in a VM.
     Bytecode,
+    // Dumps source code as AST tree.
+    DumpAst,
+    // Disassembles source code to bytecode.
+    Disassemble,
   }
 }

--- a/csharp/tests/SeedLang.Tests/Runtime/ExecutorPythonTests.cs
+++ b/csharp/tests/SeedLang.Tests/Runtime/ExecutorPythonTests.cs
@@ -143,7 +143,7 @@ array
       var executor = new Executor();
       var visualizer = new MockupVisualizer();
       executor.Register(visualizer);
-      Assert.True(executor.Run(source, "", SeedXLanguage.SeedPython, type));
+      executor.Run(source, "", SeedXLanguage.SeedPython, type);
       Assert.Equal(result, visualizer.Result.ToString());
     }
   }


### PR DESCRIPTION
- Show line numbers of source code in SeedLang.Shell, and only show related source lines when displaying evaluation results, please use following command to see the result.

```shell
dotnet run -c Release --project src/SeedLang.Shell -- -f ../examples/seedpython/scripts/sum.py
```

- Small fix for correct range when variables is not defined.
- Small fix for return a None value when execute a non-value return statement.