### PR TITLE
Implement pass statements

### DIFF
--- a/csharp/src/SeedLang/Ast/AstStringBuilder.cs
+++ b/csharp/src/SeedLang/Ast/AstStringBuilder.cs
@@ -252,6 +252,11 @@ namespace SeedLang.Ast {
       Exit();
     }
 
+    protected override void Visit(PassStatement pass) {
+      Enter(pass);
+      Exit();
+    }
+
     protected override void Visit(ReturnStatement @return) {
       Enter(@return);
       foreach (Expression value in @return.Exprs) {

--- a/csharp/src/SeedLang/Ast/AstWalker.cs
+++ b/csharp/src/SeedLang/Ast/AstWalker.cs
@@ -100,6 +100,9 @@ namespace SeedLang.Ast {
         case IfStatement @if:
           Visit(@if);
           break;
+        case PassStatement pass:
+          Visit(pass);
+          break;
         case ReturnStatement @return:
           Visit(@return);
           break;
@@ -132,6 +135,7 @@ namespace SeedLang.Ast {
     protected abstract void Visit(ForInStatement forIn);
     protected abstract void Visit(FuncDefStatement funcDef);
     protected abstract void Visit(IfStatement @if);
+    protected abstract void Visit(PassStatement pass);
     protected abstract void Visit(ReturnStatement @return);
     protected abstract void Visit(WhileStatement @while);
   }

--- a/csharp/src/SeedLang/Ast/Executor.cs
+++ b/csharp/src/SeedLang/Ast/Executor.cs
@@ -298,6 +298,9 @@ namespace SeedLang.Ast {
       }
     }
 
+    protected override void Visit(PassStatement pass) {
+    }
+
     protected override void Visit(ReturnStatement @return) {
       // Throws a return exception carried with the result value to break current execution flow and
       // return from current function.

--- a/csharp/src/SeedLang/Ast/Statements.cs
+++ b/csharp/src/SeedLang/Ast/Statements.cs
@@ -51,6 +51,11 @@ namespace SeedLang.Ast {
       return new IfStatement(test, thenBody, elseBody, range);
     }
 
+    // The factory method to create a pass statement.
+    internal static PassStatement Pass(Range range) {
+      return new PassStatement(range);
+    }
+
     // The factory method to create a return statement.
     internal static ReturnStatement Return(Expression[] exprs, Range range) {
       return new ReturnStatement(exprs, range);
@@ -133,6 +138,10 @@ namespace SeedLang.Ast {
       ThenBody = thenBody;
       ElseBody = elseBody;
     }
+  }
+
+  internal class PassStatement : Statement {
+    internal PassStatement(Range range) : base(range) { }
   }
 
   internal class ReturnStatement : Statement {

--- a/csharp/src/SeedLang/Interpreter/Compiler.cs
+++ b/csharp/src/SeedLang/Interpreter/Compiler.cs
@@ -295,6 +295,9 @@ namespace SeedLang.Interpreter {
       _nestedJumpStack.PopFrame();
     }
 
+    protected override void Visit(PassStatement pass) {
+    }
+
     protected override void Visit(ReturnStatement @return) {
       if (@return.Exprs.Length == 0) {
         _chunk.Emit(Opcode.RETURN, 0, 0, 0, @return.Range);

--- a/csharp/src/SeedLang/X/SeedPythonVisitor.cs
+++ b/csharp/src/SeedLang/X/SeedPythonVisitor.cs
@@ -65,6 +65,10 @@ namespace SeedLang.X {
       return VisitorHelper.BuildExpressionStatement(context.expressions(), this);
     }
 
+    public override AstNode VisitPass([NotNull] SeedPythonParser.PassContext context) {
+      return _helper.BuildPass(context.PASS().Symbol);
+    }
+
     public override AstNode VisitAssign([NotNull] SeedPythonParser.AssignContext context) {
       SeedPythonParser.TargetsContext targets = context.targets();
       SeedPythonParser.ExpressionsContext exprs = context.expressions();

--- a/csharp/src/SeedLang/X/VisitorHelper.cs
+++ b/csharp/src/SeedLang/X/VisitorHelper.cs
@@ -501,6 +501,13 @@ namespace SeedLang.X {
       return null;
     }
 
+    // Builds pass statements.
+    internal AstNode BuildPass(IToken passToken) {
+      TextRange range = CodeReferenceUtils.RangeOfToken(passToken);
+      AddSyntaxToken(SyntaxType.Keyword, range);
+      return Statement.Pass(range);
+    }
+
     // Builds while statements.
     internal WhileStatement BuildWhile(IToken whileToken, ParserRuleContext exprContext,
                                        IToken colonToken, ParserRuleContext blockContext,

--- a/csharp/tests/SeedLang.Tests/Ast/StatementsTest.cs
+++ b/csharp/tests/SeedLang.Tests/Ast/StatementsTest.cs
@@ -27,6 +27,7 @@ namespace SeedLang.Ast.Tests {
         AddForIn();
         AddFuncDef();
         AddIf();
+        AddPass();
         AddReturn();
         AddWhile();
       }
@@ -102,6 +103,12 @@ namespace SeedLang.Ast.Tests {
                              $"    {AstHelper.TextRange} IdentifierExpression ({name})\n" +
                              $"    {AstHelper.TextRange} NumberConstantExpression (2)";
         Add(@if, expectedOutput);
+      }
+
+      private void AddPass() {
+        var pass = AstHelper.Pass();
+        var expectedOutput = $"{AstHelper.TextRange} PassStatement";
+        Add(pass, expectedOutput);
       }
 
       private void AddReturn() {

--- a/csharp/tests/SeedLang.Tests/Helper/AstHelper.cs
+++ b/csharp/tests/SeedLang.Tests/Helper/AstHelper.cs
@@ -98,6 +98,10 @@ namespace SeedLang.Tests.Helper {
       return Expression.NumberConstant(value, TextRange);
     }
 
+    internal static PassStatement Pass() {
+      return Statement.Pass(TextRange);
+    }
+
     internal static ReturnStatement Return(params Expression[] exprs) {
       return Statement.Return(exprs, TextRange);
     }

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonStatementTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonStatementTests.cs
@@ -387,6 +387,24 @@ namespace SeedLang.X.Tests {
                 "Parenthesis [Ln 1, Col 23 - Ln 1, Col 23]," +
                 "Symbol [Ln 1, Col 24 - Ln 1, Col 24]," +
                 "Variable [Ln 1, Col 26 - Ln 1, Col 26]")]
+
+    [InlineData("if True:\n" +
+                "  pass\n" +
+                "else:\n" +
+                "  pass",
+
+                "[Ln 1, Col 0 - Ln 4, Col 5] IfStatement\n" +
+                "  [Ln 1, Col 3 - Ln 1, Col 6] BooleanConstantExpression (True)\n" +
+                "  [Ln 2, Col 2 - Ln 2, Col 5] PassStatement\n" +
+                "  [Ln 4, Col 2 - Ln 4, Col 5] PassStatement",
+
+                "Keyword [Ln 1, Col 0 - Ln 1, Col 1]," +
+                "Boolean [Ln 1, Col 3 - Ln 1, Col 6]," +
+                "Symbol [Ln 1, Col 7 - Ln 1, Col 7]," +
+                "Keyword [Ln 2, Col 2 - Ln 2, Col 5]," +
+                "Keyword [Ln 3, Col 0 - Ln 3, Col 3]," +
+                "Symbol [Ln 3, Col 4 - Ln 3, Col 4]," +
+                "Keyword [Ln 4, Col 2 - Ln 4, Col 5]")]
     public void TestPythonParser(string input, string expectedAst, string expectedTokens) {
       Assert.True(_parser.Parse(input, "", _collection, out AstNode node,
                                 out IReadOnlyList<SyntaxToken> tokens));

--- a/examples/seedpython/scripts/function.py
+++ b/examples/seedpython/scripts/function.py
@@ -1,5 +1,4 @@
 def fib(n):
-    """Print a Fibonacci series up to n."""
     a, b = 0, 1
     while a < n:
         a
@@ -13,7 +12,6 @@ f(100)  # 0 1 1 2 3 5 8 13 21 34 55 89
 
 
 def fib_list(n):
-    """Return a list containing the Fibonacci series up to n."""
     result = []
     a, b = 0, 1
     while a < n:
@@ -36,8 +34,4 @@ fib_recursive(10)  # 55
 
 
 def my_func():
-    """Do nothing, but document it.
-
-    No, really, it doesn't do anything.
-    """
     pass

--- a/examples/seedpython/scripts/string.py
+++ b/examples/seedpython/scripts/string.py
@@ -10,12 +10,6 @@
 '"Yes," they said.'  # "Yes," they said.
 '"Isn\'t," they said.'  # "Isn\'t," they said.
 
-"""
-Usage: thingy [OPTIONS]
-     -h                        Display this usage message
-     -H hostname               Hostname to connect to
-"""
-
 3 * "un" + "ium"  # unununium
 "Py" "thon"  # Python
 

--- a/grammars/SeedPython.g4
+++ b/grammars/SeedPython.g4
@@ -41,7 +41,7 @@ simple_stmt:
   assignment    # assignment_placeholder
   | expressions # expression_stmt
   | return_stmt # return_stmt_placeholder
-  | 'pass'      # pass
+  | PASS        # pass
   | 'break'     # break
   | 'continue'  # continue;
 
@@ -99,6 +99,7 @@ IN: 'in';
 WHILE: 'while';
 DEF: 'def';
 RETURN: 'return';
+PASS: 'pass';
 
 COLON: ':';
 SEMICOLON: ';';


### PR DESCRIPTION
Supports following code:

```python
def func():
    pass
```

Removed docstring `""" ... """` in example scripts, not plan to implement it now.