### PR TITLE
Add parser benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
         run: dotnet build --no-restore
       - name: Benchmark
         working-directory: ./csharp
-        run: dotnet run -c Release --project benchmark/SeedLang.Benchmark
+        run: dotnet run -c Release --project benchmark/SeedLang.Benchmark -- -f '*'
       - name: Check out wiki
         uses: actions/checkout@v2
         with:

--- a/csharp/benchmark/SeedLang.Benchmark/ParserBenchmark.cs
+++ b/csharp/benchmark/SeedLang.Benchmark/ParserBenchmark.cs
@@ -1,0 +1,62 @@
+// Copyright 2021-2022 The SeedV Lab.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using BenchmarkDotNet.Attributes;
+using SeedLang.Runtime;
+
+namespace SeedLang.Benchmark {
+  // Code editors can use SeedLang's syntax parsing result to highlight syntax/semantic tokens.
+  // Hence, we measure the performance of the parser separately with this benchmark.
+  public class ParserBenchmark {
+    private readonly string _pythonCode = @"def get_sum(min, max):
+  i = min
+  sum = 0
+  while i <= max:
+    sum = sum + i
+    i = i + 1
+  return sum
+
+def fib1(n):
+  a, b = 0, 1
+  i = 1
+  while i < n:
+    a, b = b, a + b
+    i = i + 1
+  return b
+
+def fib2(n):
+  a, b = 0, 1
+  for i in range(1, n):
+    a, b = b, a + b
+  return b
+
+def fib3(n):
+  if n == 1 or n == 2:
+    return 1
+  else:
+    return fib(n - 1) + fib(n - 2)
+";
+
+    [Benchmark]
+    public void BenchmarkParsePython() {
+      Executor.ParseSyntaxTokens(_pythonCode, "", SeedXLanguage.SeedPython, null);
+    }
+
+    [Benchmark]
+    public void BenchmarkParsePythonWithSyntaxErrors() {
+      var codeWithErrors = _pythonCode.Replace("return", "$$$");
+      Executor.ParseSyntaxTokens(codeWithErrors, "", SeedXLanguage.SeedPython, null);
+    }
+  }
+}

--- a/csharp/benchmark/SeedLang.Benchmark/Program.cs
+++ b/csharp/benchmark/SeedLang.Benchmark/Program.cs
@@ -12,52 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
 using BenchmarkDotNet.Running;
-using CommandLine;
-using CommandLine.Text;
 
 namespace SeedLang.Benchmark {
   class Program {
-    internal enum BenchmarkType {
-      Fib,
-      Parser,
-      Sum,
-      All,
-    }
-
-    internal class Options {
-      [Option('b', "Benchmark", Required = false, Default = BenchmarkType.All,
-              HelpText = "The benchmark to run.")]
-      public BenchmarkType BenchmarkType { get; set; }
-    }
-
-    private static readonly Dictionary<BenchmarkType, Type> _benchmarks =
-        new Dictionary<BenchmarkType, Type> {
-          [BenchmarkType.Fib] = typeof(FibBenchmark),
-          [BenchmarkType.Parser] = typeof(ParserBenchmark),
-          [BenchmarkType.Sum] = typeof(SumBenchmark),
-        };
-
     static void Main(string[] args) {
-      var parser = new Parser(with => with.HelpWriter = null);
-      var result = parser.ParseArguments<Options>(args);
-      var helpText = HelpText.AutoBuild(result, h => {
-        h.AddEnumValuesToHelpText = true;
-        return HelpText.DefaultParsingErrorsHandler(result, h);
-      }, e => e);
-      result.WithParsed<Options>(options => {
-        if (options.BenchmarkType == BenchmarkType.All) {
-          foreach (var benchmark in _benchmarks.Values) {
-            BenchmarkRunner.Run(benchmark);
-          }
-        } else {
-          BenchmarkRunner.Run(_benchmarks[options.BenchmarkType]);
-        }
-      }).WithNotParsed(errors => {
-        Console.Error.Write(helpText);
-      });
+      BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
     }
   }
 }

--- a/csharp/benchmark/SeedLang.Benchmark/SeedLang.Benchmark.csproj
+++ b/csharp/benchmark/SeedLang.Benchmark/SeedLang.Benchmark.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/benchmark/SeedLang.Benchmark/SeedLang.Benchmark.csproj
+++ b/csharp/benchmark/SeedLang.Benchmark/SeedLang.Benchmark.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/benchmark/SeedLang.Benchmark/update_wiki.sh
+++ b/csharp/benchmark/SeedLang.Benchmark/update_wiki.sh
@@ -32,6 +32,14 @@ END
 
   cat <<END
 
+## Parser
+
+END
+
+  cat ${results_path}/SeedLang.Benchmark.ParserBenchmark-report-github.md
+
+  cat <<END
+
 ## Sum
 
 END


### PR DESCRIPTION
* Add a separate benchmark for the syntax token parser.
* Add commandline options to SeedLang.Benchmark to choose benchmark to run.