### PR TITLE
Fix first line comment parsing issue

### DIFF
--- a/csharp/src/SeedLang/Ast/Expressions.cs
+++ b/csharp/src/SeedLang/Ast/Expressions.cs
@@ -64,7 +64,7 @@ namespace SeedLang.Ast {
 
     // The factory method to create a string constant expression.
     internal static StringConstantExpression StringConstant(string value, Range range) {
-      return new StringConstantExpression(value, range);
+      return new StringConstantExpression(ValueHelper.Unescape(value), range);
     }
 
     // The factory method to create a list expression.

--- a/csharp/src/SeedLang/Runtime/HeapObject.cs
+++ b/csharp/src/SeedLang/Runtime/HeapObject.cs
@@ -53,11 +53,7 @@ namespace SeedLang.Runtime {
     private readonly object _object;
 
     public HeapObject(object obj) {
-      if (obj is string str) {
-        _object = ValueHelper.Unescape(str);
-      } else {
-        _object = obj;
-      }
+      _object = obj;
       Debug.Assert(IsString || IsList || IsFunction || IsRange || IsTuple,
                    $"Unsupported object type: {_object.GetType()}");
     }

--- a/csharp/src/SeedLang/X/SeedPythonDentLexer.cs
+++ b/csharp/src/SeedLang/X/SeedPythonDentLexer.cs
@@ -46,7 +46,7 @@ namespace SeedLang.X {
         IToken currentToken = base.NextToken();
         if (_firstToken) {
           _firstToken = false;
-          HandleFirstToken(currentToken);
+          HandleIndentForFirstToken(currentToken);
         }
         switch (currentToken.Type) {
           case SeedPythonParser.NEWLINE:
@@ -84,8 +84,8 @@ namespace SeedLang.X {
       _addTrailingNewline = true;
     }
 
-    private void HandleFirstToken(IToken firstToken) {
-      if (firstToken.StartIndex > 0) {
+    private void HandleIndentForFirstToken(IToken firstToken) {
+      if (firstToken.Type != SeedPythonParser.NEWLINE && firstToken.StartIndex > 0) {
         var interval = new Interval(0, firstToken.StartIndex - 1);
         string spaces = (InputStream as ICharStream).GetText(interval);
         int indent = GetIndentationCount(spaces);

--- a/csharp/src/SeedLang/X/SeedPythonVisitor.cs
+++ b/csharp/src/SeedLang/X/SeedPythonVisitor.cs
@@ -36,28 +36,16 @@ namespace SeedLang.X {
 
     public override AstNode VisitProgram([NotNull] SeedPythonParser.ProgramContext context) {
       ParserRuleContext statements = context.statements();
-      if (statements is null) {
-        // TODO: return a null block AST node.
-        return null;
-      }
       return Visit(statements);
     }
 
     public override AstNode VisitStatements([NotNull] SeedPythonParser.StatementsContext context) {
-      ParserRuleContext[] statements = context.statement();
-      if (statements.Length == 1) {
-        return Visit(statements[0]);
-      }
-      return VisitorHelper.BuildBlock(statements, this);
+      return VisitorHelper.BuildBlock(context.NEWLINE(), context.statement(), this);
     }
 
     public override AstNode VisitSimple_stmts(
         [NotNull] SeedPythonParser.Simple_stmtsContext context) {
-      ParserRuleContext[] statements = context.simple_stmt();
-      if (statements.Length == 1) {
-        return Visit(statements[0]);
-      }
-      return _helper.BuildSimpleStatements(statements, context.SEMICOLON(), this);
+      return _helper.BuildSimpleStatements(context.simple_stmt(), context.SEMICOLON(), this);
     }
 
     public override AstNode VisitExpression_stmt(

--- a/csharp/src/SeedLang/X/VisitorHelper.cs
+++ b/csharp/src/SeedLang/X/VisitorHelper.cs
@@ -365,8 +365,19 @@ namespace SeedLang.X {
     }
 
     // Builds block statements.
-    internal static BlockStatement BuildBlock(ParserRuleContext[] statementContexts,
-                                              AbstractParseTreeVisitor<AstNode> visitor) {
+    internal static AstNode BuildBlock(ITerminalNode[] newLineNodes,
+                                       ParserRuleContext[] statementContexts,
+                                       AbstractParseTreeVisitor<AstNode> visitor) {
+      if (statementContexts.Length == 0) {
+        TextRange range = null;
+        if (newLineNodes.Length > 0) {
+          range = CodeReferenceUtils.RangeOfTokens(newLineNodes[0].Symbol,
+                                                   newLineNodes[newLineNodes.Length - 1].Symbol);
+        }
+        return Statement.Block(System.Array.Empty<Statement>(), range);
+      } else if (statementContexts.Length == 1) {
+        return visitor.Visit(statementContexts[0]);
+      }
       var statements = new Statement[statementContexts.Length];
       for (int i = 0; i < statementContexts.Length; i++) {
         statements[i] = visitor.Visit(statementContexts[i]) as Statement;
@@ -486,9 +497,12 @@ namespace SeedLang.X {
     }
 
     // Builds a block of simple statements.
-    internal BlockStatement BuildSimpleStatements(ParserRuleContext[] statementContexts,
-                                                  ITerminalNode[] semicolonNodes,
-                                                  AbstractParseTreeVisitor<AstNode> visitor) {
+    internal AstNode BuildSimpleStatements(ParserRuleContext[] statementContexts,
+                                           ITerminalNode[] semicolonNodes,
+                                           AbstractParseTreeVisitor<AstNode> visitor) {
+      if (statementContexts.Length == 1) {
+        return visitor.Visit(statementContexts[0]);
+      }
       Debug.Assert(statementContexts.Length == semicolonNodes.Length + 1 ||
                    statementContexts.Length == semicolonNodes.Length);
       var statements = new Statement[statementContexts.Length];

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonDentLexerTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonDentLexerTests.cs
@@ -18,134 +18,126 @@ using Xunit;
 
 namespace SeedLang.X.Tests {
   public class SeedPythonDentLexerTests {
-    internal class TestData : TheoryData<string, string[]> {
-      private const int _add = SeedPythonParser.ADD;
-      private const int _colon = SeedPythonParser.COLON;
-      private const int _dedent = SeedPythonParser.DEDENT;
-      private const int _else = SeedPythonParser.ELSE;
-      private const int _equal = SeedPythonParser.EQUAL;
-      private const int _false = SeedPythonParser.FALSE;
-      private const int _if = SeedPythonParser.IF;
-      private const int _indent = SeedPythonParser.INDENT;
-      private const int _name = SeedPythonParser.NAME;
-      private const int _newline = SeedPythonParser.NEWLINE;
-      private const int _number = SeedPythonParser.NUMBER;
-      private const int _true = SeedPythonParser.TRUE;
-      private const int _while = SeedPythonParser.WHILE;
-
-      public TestData() {
-        AddExpressionStatement();
-        AddWhileBlock();
-        AddWhileTrue();
-        AddWhileWithIf();
-        AddSingleLineWhile();
-      }
-
-      private void AddExpressionStatement() {
-        string source = "1 + 2\n";
-        var expectedTokens = new string[] {
-          $"[@-1,0:0='1',<{_number}>,1:0]",
-          $"[@-1,2:2='+',<{_add}>,1:2]",
-          $"[@-1,4:4='2',<{_number}>,1:4]",
-          $"[@-1,5:5='\\n',<{_newline}>,1:5]",
-        };
-        Add(source, expectedTokens);
-      }
-
-
-      private void AddWhileBlock() {
-        string source = "while True:\n" +
-                        "  x = 1\n" +
-                        "  y = 2";
-        var expectedTokens = new string[] {
-          $"[@-1,0:4='while',<{_while}>,1:0]",
-          $"[@-1,6:9='True',<{_true}>,1:6]",
-          $"[@-1,10:10=':',<{_colon}>,1:10]",
-          $"[@-1,11:11='\\n',<{_newline}>,1:11]",
-          $"[@-1,12:13='  ',<{_indent}>,2:0]",
-          $"[@-1,14:14='x',<{_name}>,2:2]",
-          $"[@-1,16:16='=',<{_equal}>,2:4]",
-          $"[@-1,18:18='1',<{_number}>,2:6]",
-          $"[@-1,19:21='\\n  ',<{_newline}>,2:7]",
-          $"[@-1,22:22='y',<{_name}>,3:2]",
-          $"[@-1,24:24='=',<{_equal}>,3:4]",
-          $"[@-1,26:26='2',<{_number}>,3:6]",
-          $"[@-1,27:27='\\n',<{_newline}>,3:7]",
-          $"[@-1,27:27='',<{_dedent}>,4:0]",
-        };
-        Add(source, expectedTokens);
-      }
-
-      private void AddWhileTrue() {
-        string source = "while True";
-        var expectedTokens = new string[] {
-          $"[@-1,0:4='while',<{_while}>,1:0]",
-          $"[@-1,6:9='True',<{_true}>,1:6]",
-          $"[@-1,10:10='\\n',<{_newline}>,1:10]",
-        };
-        Add(source, expectedTokens);
-      }
-
-      private void AddWhileWithIf() {
-        string source = "while True:\n" +
-                        "  if False:\n" +
-                        "    x = 1\n" +
-                        "  else:\n" +
-                        "      y = 2";
-        var expectedTokens = new string[] {
-          $"[@-1,0:4='while',<{_while}>,1:0]",
-          $"[@-1,6:9='True',<{_true}>,1:6]",
-          $"[@-1,10:10=':',<{_colon}>,1:10]",
-          $"[@-1,11:11='\\n',<{_newline}>,1:11]",
-          $"[@-1,12:13='  ',<{_indent}>,2:0]",
-          $"[@-1,14:15='if',<{_if}>,2:2]",
-          $"[@-1,17:21='False',<{_false}>,2:5]",
-          $"[@-1,22:22=':',<{_colon}>,2:10]",
-          $"[@-1,23:23='\\n',<{_newline}>,2:11]",
-          $"[@-1,24:27='    ',<{_indent}>,3:0]",
-          $"[@-1,28:28='x',<{_name}>,3:4]",
-          $"[@-1,30:30='=',<{_equal}>,3:6]",
-          $"[@-1,32:32='1',<{_number}>,3:8]",
-          $"[@-1,33:33='\\n',<{_newline}>,3:9]",
-          $"[@-1,34:35='  ',<{_dedent}>,4:0]",
-          $"[@-1,36:39='else',<{_else}>,4:2]",
-          $"[@-1,40:40=':',<{_colon}>,4:6]",
-          $"[@-1,41:41='\\n',<{_newline}>,4:7]",
-          $"[@-1,42:47='      ',<{_indent}>,5:0]",
-          $"[@-1,48:48='y',<{_name}>,5:6]",
-          $"[@-1,50:50='=',<{_equal}>,5:8]",
-          $"[@-1,52:52='2',<{_number}>,5:10]",
-          $"[@-1,53:53='\\n',<{_newline}>,5:11]",
-          $"[@-1,53:53='',<{_dedent}>,6:0]",
-          $"[@-1,53:53='',<{_dedent}>,6:0]",
-        };
-        Add(source, expectedTokens);
-      }
-
-      private void AddSingleLineWhile() {
-        string source = "  while True:\n \tx = 1";
-        var expectedTokens = new string[] {
-          $"[@-1,0:0='\\n',<{_newline}>,1:0]",
-          $"[@-1,0:1='  ',<{_indent}>,1:0]",
-          $"[@-1,2:6='while',<{_while}>,1:2]",
-          $"[@-1,8:11='True',<{_true}>,1:8]",
-          $"[@-1,12:12=':',<{_colon}>,1:12]",
-          $"[@-1,13:13='\\n',<{_newline}>,1:13]",
-          $"[@-1,14:15=' \\t',<{_indent}>,2:0]",
-          $"[@-1,16:16='x',<{_name}>,2:2]",
-          $"[@-1,18:18='=',<{_equal}>,2:4]",
-          $"[@-1,20:20='1',<{_number}>,2:6]",
-          $"[@-1,21:21='\\n',<{_newline}>,2:7]",
-          $"[@-1,21:21='',<{_dedent}>,3:0]",
-          $"[@-1,21:21='',<{_dedent}>,3:0]",
-        };
-        Add(source, expectedTokens);
-      }
+    [Fact]
+    public void TestComments() {
+      string source = "# comment\nprint(1)";
+      var expectedTokens = new string[] {
+          $"[@-1,9:9='\\n',<{SeedPythonParser.NEWLINE}>,1:9]",
+          $"[@-1,10:14='print',<{SeedPythonParser.NAME}>,2:0]",
+          $"[@-1,15:15='(',<{SeedPythonParser.OPEN_PAREN}>,2:5]",
+          $"[@-1,16:16='1',<{SeedPythonParser.NUMBER}>,2:6]",
+          $"[@-1,17:17=')',<{SeedPythonParser.CLOSE_PAREN}>,2:7]",
+          $"[@-1,18:18='\\n',<{SeedPythonParser.NEWLINE}>,2:8]",
+      };
+      TestScanTokens(source, expectedTokens);
     }
 
-    [Theory]
-    [ClassData(typeof(TestData))]
-    public void TestScanTokens(string source, string[] expectedTokens) {
+    [Fact]
+    public void TestExpressionStatement() {
+      string source = "1 + 2\n";
+      var expectedTokens = new string[] {
+          $"[@-1,0:0='1',<{SeedPythonParser.NUMBER}>,1:0]",
+          $"[@-1,2:2='+',<{SeedPythonParser.ADD}>,1:2]",
+          $"[@-1,4:4='2',<{SeedPythonParser.NUMBER}>,1:4]",
+          $"[@-1,5:5='\\n',<{SeedPythonParser.NEWLINE}>,1:5]",
+      };
+      TestScanTokens(source, expectedTokens);
+    }
+
+    [Fact]
+    public void TestWhileTrue() {
+      string source = "while True";
+      var expectedTokens = new string[] {
+          $"[@-1,0:4='while',<{SeedPythonParser.WHILE}>,1:0]",
+          $"[@-1,6:9='True',<{SeedPythonParser.TRUE}>,1:6]",
+          $"[@-1,10:10='\\n',<{SeedPythonParser.NEWLINE}>,1:10]",
+      };
+      TestScanTokens(source, expectedTokens);
+    }
+
+    [Fact]
+    public void TestSingleWhile() {
+      string source = "  while True:\n \tx = 1";
+      var expectedTokens = new string[] {
+          $"[@-1,0:0='\\n',<{SeedPythonParser.NEWLINE}>,1:0]",
+          $"[@-1,0:1='  ',<{SeedPythonParser.INDENT}>,1:0]",
+          $"[@-1,2:6='while',<{SeedPythonParser.WHILE}>,1:2]",
+          $"[@-1,8:11='True',<{SeedPythonParser.TRUE}>,1:8]",
+          $"[@-1,12:12=':',<{SeedPythonParser.COLON}>,1:12]",
+          $"[@-1,13:13='\\n',<{SeedPythonParser.NEWLINE}>,1:13]",
+          $"[@-1,14:15=' \\t',<{SeedPythonParser.INDENT}>,2:0]",
+          $"[@-1,16:16='x',<{SeedPythonParser.NAME}>,2:2]",
+          $"[@-1,18:18='=',<{SeedPythonParser.EQUAL}>,2:4]",
+          $"[@-1,20:20='1',<{SeedPythonParser.NUMBER}>,2:6]",
+          $"[@-1,21:21='\\n',<{SeedPythonParser.NEWLINE}>,2:7]",
+          $"[@-1,21:21='',<{SeedPythonParser.DEDENT}>,3:0]",
+          $"[@-1,21:21='',<{SeedPythonParser.DEDENT}>,3:0]",
+      };
+      TestScanTokens(source, expectedTokens);
+    }
+
+    [Fact]
+    public void TestWhileBlock() {
+      string source = "while True:\n" +
+                      "  x = 1\n" +
+                      "  y = 2";
+      var expectedTokens = new string[] {
+          $"[@-1,0:4='while',<{SeedPythonParser.WHILE}>,1:0]",
+          $"[@-1,6:9='True',<{SeedPythonParser.TRUE}>,1:6]",
+          $"[@-1,10:10=':',<{SeedPythonParser.COLON}>,1:10]",
+          $"[@-1,11:11='\\n',<{SeedPythonParser.NEWLINE}>,1:11]",
+          $"[@-1,12:13='  ',<{SeedPythonParser.INDENT}>,2:0]",
+          $"[@-1,14:14='x',<{SeedPythonParser.NAME}>,2:2]",
+          $"[@-1,16:16='=',<{SeedPythonParser.EQUAL}>,2:4]",
+          $"[@-1,18:18='1',<{SeedPythonParser.NUMBER}>,2:6]",
+          $"[@-1,19:21='\\n  ',<{SeedPythonParser.NEWLINE}>,2:7]",
+          $"[@-1,22:22='y',<{SeedPythonParser.NAME}>,3:2]",
+          $"[@-1,24:24='=',<{SeedPythonParser.EQUAL}>,3:4]",
+          $"[@-1,26:26='2',<{SeedPythonParser.NUMBER}>,3:6]",
+          $"[@-1,27:27='\\n',<{SeedPythonParser.NEWLINE}>,3:7]",
+          $"[@-1,27:27='',<{SeedPythonParser.DEDENT}>,4:0]",
+      };
+      TestScanTokens(source, expectedTokens);
+    }
+
+    [Fact]
+    public void TestWhileWithIf() {
+      string source = "while True:\n" +
+                      "  if False:\n" +
+                      "    x = 1\n" +
+                      "  else:\n" +
+                      "      y = 2";
+      var expectedTokens = new string[] {
+          $"[@-1,0:4='while',<{SeedPythonParser.WHILE}>,1:0]",
+          $"[@-1,6:9='True',<{SeedPythonParser.TRUE}>,1:6]",
+          $"[@-1,10:10=':',<{SeedPythonParser.COLON}>,1:10]",
+          $"[@-1,11:11='\\n',<{SeedPythonParser.NEWLINE}>,1:11]",
+          $"[@-1,12:13='  ',<{SeedPythonParser.INDENT}>,2:0]",
+          $"[@-1,14:15='if',<{SeedPythonParser.IF}>,2:2]",
+          $"[@-1,17:21='False',<{SeedPythonParser.FALSE}>,2:5]",
+          $"[@-1,22:22=':',<{SeedPythonParser.COLON}>,2:10]",
+          $"[@-1,23:23='\\n',<{SeedPythonParser.NEWLINE}>,2:11]",
+          $"[@-1,24:27='    ',<{SeedPythonParser.INDENT}>,3:0]",
+          $"[@-1,28:28='x',<{SeedPythonParser.NAME}>,3:4]",
+          $"[@-1,30:30='=',<{SeedPythonParser.EQUAL}>,3:6]",
+          $"[@-1,32:32='1',<{SeedPythonParser.NUMBER}>,3:8]",
+          $"[@-1,33:33='\\n',<{SeedPythonParser.NEWLINE}>,3:9]",
+          $"[@-1,34:35='  ',<{SeedPythonParser.DEDENT}>,4:0]",
+          $"[@-1,36:39='else',<{SeedPythonParser.ELSE}>,4:2]",
+          $"[@-1,40:40=':',<{SeedPythonParser.COLON}>,4:6]",
+          $"[@-1,41:41='\\n',<{SeedPythonParser.NEWLINE}>,4:7]",
+          $"[@-1,42:47='      ',<{SeedPythonParser.INDENT}>,5:0]",
+          $"[@-1,48:48='y',<{SeedPythonParser.NAME}>,5:6]",
+          $"[@-1,50:50='=',<{SeedPythonParser.EQUAL}>,5:8]",
+          $"[@-1,52:52='2',<{SeedPythonParser.NUMBER}>,5:10]",
+          $"[@-1,53:53='\\n',<{SeedPythonParser.NEWLINE}>,5:11]",
+          $"[@-1,53:53='',<{SeedPythonParser.DEDENT}>,6:0]",
+          $"[@-1,53:53='',<{SeedPythonParser.DEDENT}>,6:0]",
+      };
+      TestScanTokens(source, expectedTokens);
+    }
+
+    private static void TestScanTokens(string source, string[] expectedTokens) {
       var inputStream = new AntlrInputStream(source);
       var lexer = new SeedPythonDentLexer(inputStream);
       IList<IToken> tokens = lexer.GetAllTokens();

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonStatementTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonStatementTests.cs
@@ -20,431 +20,483 @@ using Xunit;
 
 namespace SeedLang.X.Tests {
   public class SeedPythonStatementTests {
-    private readonly DiagnosticCollection _collection = new DiagnosticCollection();
-    private readonly SeedPython _parser = new SeedPython();
+    [Fact]
+    public void TestComments() {
+      string source = "# comment\nprint(1)";
+      string expected = "[Ln 2, Col 0 - Ln 2, Col 7] ExpressionStatement\n" +
+                        "  [Ln 2, Col 0 - Ln 2, Col 7] CallExpression\n" +
+                        "    [Ln 2, Col 0 - Ln 2, Col 4] IdentifierExpression (print)\n" +
+                        "    [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)";
+      string expectedTokens = "Variable [Ln 2, Col 0 - Ln 2, Col 4]," +
+                              "OpenParenthesis [Ln 2, Col 5 - Ln 2, Col 5]," +
+                              "Number [Ln 2, Col 6 - Ln 2, Col 6]," +
+                              "CloseParenthesis [Ln 2, Col 7 - Ln 2, Col 7]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-    [Theory]
-    [InlineData("x = 1",
+    [Fact]
+    public void TestAssignment() {
+      string source = "x = 1";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 4] AssignmentStatement\n" +
+                        "  [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x)\n" +
+                        "  [Ln 1, Col 4 - Ln 1, Col 4] NumberConstantExpression (1)";
+      string expectedTokens = "Variable [Ln 1, Col 0 - Ln 1, Col 0]," +
+                              "Operator [Ln 1, Col 2 - Ln 1, Col 2]," +
+                              "Number [Ln 1, Col 4 - Ln 1, Col 4]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-                "[Ln 1, Col 0 - Ln 1, Col 4] AssignmentStatement\n" +
-                "  [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x)\n" +
-                "  [Ln 1, Col 4 - Ln 1, Col 4] NumberConstantExpression (1)",
+    [Fact]
+    public void TestMultipleAssignment() {
+      string source = "x, y = 1, 2";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 10] AssignmentStatement\n" +
+                        "  [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x)\n" +
+                        "  [Ln 1, Col 3 - Ln 1, Col 3] IdentifierExpression (y)\n" +
+                        "  [Ln 1, Col 7 - Ln 1, Col 7] NumberConstantExpression (1)\n" +
+                        "  [Ln 1, Col 10 - Ln 1, Col 10] NumberConstantExpression (2)";
+      string expectedTokens = "Variable [Ln 1, Col 0 - Ln 1, Col 0]," +
+                              "Symbol [Ln 1, Col 1 - Ln 1, Col 1]," +
+                              "Variable [Ln 1, Col 3 - Ln 1, Col 3]," +
+                              "Operator [Ln 1, Col 5 - Ln 1, Col 5]," +
+                              "Number [Ln 1, Col 7 - Ln 1, Col 7]," +
+                              "Symbol [Ln 1, Col 8 - Ln 1, Col 8]," +
+                              "Number [Ln 1, Col 10 - Ln 1, Col 10]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-                "Variable [Ln 1, Col 0 - Ln 1, Col 0]," +
-                "Operator [Ln 1, Col 2 - Ln 1, Col 2]," +
-                "Number [Ln 1, Col 4 - Ln 1, Col 4]")]
+    [Fact]
+    public void TestAugmentedAssignment() {
+      string source = "x += 1";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 5] AssignmentStatement\n" +
+                        "  [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x)\n" +
+                        "  [Ln 1, Col 0 - Ln 1, Col 5] BinaryExpression (+)\n" +
+                        "    [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x)\n" +
+                        "    [Ln 1, Col 5 - Ln 1, Col 5] NumberConstantExpression (1)";
+      string expectedTokens = "Variable [Ln 1, Col 0 - Ln 1, Col 0]," +
+                              "Operator [Ln 1, Col 2 - Ln 1, Col 3]," +
+                              "Number [Ln 1, Col 5 - Ln 1, Col 5]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-    [InlineData("x += 1",
+    [Fact]
+    public void TestStringAssignment() {
+      string source = "str = 'test string'";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 18] AssignmentStatement\n" +
+                        "  [Ln 1, Col 0 - Ln 1, Col 2] IdentifierExpression (str)\n" +
+                        "  [Ln 1, Col 6 - Ln 1, Col 18] StringConstantExpression (test string)";
+      string expectedTokens = "Variable [Ln 1, Col 0 - Ln 1, Col 2]," +
+                              "Operator [Ln 1, Col 4 - Ln 1, Col 4]," +
+                              "String [Ln 1, Col 6 - Ln 1, Col 18]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-                "[Ln 1, Col 0 - Ln 1, Col 5] AssignmentStatement\n" +
-                "  [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x)\n" +
-                "  [Ln 1, Col 0 - Ln 1, Col 5] BinaryExpression (+)\n" +
-                "    [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x)\n" +
-                "    [Ln 1, Col 5 - Ln 1, Col 5] NumberConstantExpression (1)",
+    [Fact]
+    public void TestMultipleStringAssignment() {
+      string source = "str = 'a' \"b\" 'c'";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 16] AssignmentStatement\n" +
+                        "  [Ln 1, Col 0 - Ln 1, Col 2] IdentifierExpression (str)\n" +
+                        "  [Ln 1, Col 6 - Ln 1, Col 16] StringConstantExpression (abc)";
+      string expectedTokens = "Variable [Ln 1, Col 0 - Ln 1, Col 2]," +
+                              "Operator [Ln 1, Col 4 - Ln 1, Col 4]," +
+                              "String [Ln 1, Col 6 - Ln 1, Col 8]," +
+                              "String [Ln 1, Col 10 - Ln 1, Col 12]," +
+                              "String [Ln 1, Col 14 - Ln 1, Col 16]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-                "Variable [Ln 1, Col 0 - Ln 1, Col 0]," +
-                "Operator [Ln 1, Col 2 - Ln 1, Col 3]," +
-                "Number [Ln 1, Col 5 - Ln 1, Col 5]")]
+    [Fact]
+    public void TestIf() {
+      string source = "if 1 < 2: x = 1";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 14] IfStatement\n" +
+                        "  [Ln 1, Col 3 - Ln 1, Col 7] ComparisonExpression\n" +
+                        "    [Ln 1, Col 3 - Ln 1, Col 3] NumberConstantExpression (1) (<)\n" +
+                        "    [Ln 1, Col 7 - Ln 1, Col 7] NumberConstantExpression (2)\n" +
+                        "  [Ln 1, Col 10 - Ln 1, Col 14] AssignmentStatement\n" +
+                        "    [Ln 1, Col 10 - Ln 1, Col 10] IdentifierExpression (x)\n" +
+                        "    [Ln 1, Col 14 - Ln 1, Col 14] NumberConstantExpression (1)";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 1]," +
+                              "Number [Ln 1, Col 3 - Ln 1, Col 3]," +
+                              "Operator [Ln 1, Col 5 - Ln 1, Col 5]," +
+                              "Number [Ln 1, Col 7 - Ln 1, Col 7]," +
+                              "Symbol [Ln 1, Col 8 - Ln 1, Col 8]," +
+                              "Variable [Ln 1, Col 10 - Ln 1, Col 10]," +
+                              "Operator [Ln 1, Col 12 - Ln 1, Col 12]," +
+                              "Number [Ln 1, Col 14 - Ln 1, Col 14]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-    [InlineData("x, y = 1, 2",
+    [Fact]
+    public void TestIfElse() {
+      string source = "if True:\n" +
+                      "  x = 1\n" +
+                      "else:\n" +
+                      "  x = 2";
+      string expected = "[Ln 1, Col 0 - Ln 4, Col 6] IfStatement\n" +
+                        "  [Ln 1, Col 3 - Ln 1, Col 6] BooleanConstantExpression (True)\n" +
+                        "  [Ln 2, Col 2 - Ln 2, Col 6] AssignmentStatement\n" +
+                        "    [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (x)\n" +
+                        "    [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)\n" +
+                        "  [Ln 4, Col 2 - Ln 4, Col 6] AssignmentStatement\n" +
+                        "    [Ln 4, Col 2 - Ln 4, Col 2] IdentifierExpression (x)\n" +
+                        "    [Ln 4, Col 6 - Ln 4, Col 6] NumberConstantExpression (2)";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 1]," +
+                              "Boolean [Ln 1, Col 3 - Ln 1, Col 6]," +
+                              "Symbol [Ln 1, Col 7 - Ln 1, Col 7]," +
+                              "Variable [Ln 2, Col 2 - Ln 2, Col 2]," +
+                              "Operator [Ln 2, Col 4 - Ln 2, Col 4]," +
+                              "Number [Ln 2, Col 6 - Ln 2, Col 6]," +
+                              "Keyword [Ln 3, Col 0 - Ln 3, Col 3]," +
+                              "Symbol [Ln 3, Col 4 - Ln 3, Col 4]," +
+                              "Variable [Ln 4, Col 2 - Ln 4, Col 2]," +
+                              "Operator [Ln 4, Col 4 - Ln 4, Col 4]," +
+                              "Number [Ln 4, Col 6 - Ln 4, Col 6]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-                "[Ln 1, Col 0 - Ln 1, Col 10] AssignmentStatement\n" +
-                "  [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x)\n" +
-                "  [Ln 1, Col 3 - Ln 1, Col 3] IdentifierExpression (y)\n" +
-                "  [Ln 1, Col 7 - Ln 1, Col 7] NumberConstantExpression (1)\n" +
-                "  [Ln 1, Col 10 - Ln 1, Col 10] NumberConstantExpression (2)",
+    [Fact]
+    public void TestIfElseWithPassStatement() {
+      string source = "if True:\n" +
+                      "  pass\n" +
+                      "else:\n" +
+                      "  pass";
+      string expected = "[Ln 1, Col 0 - Ln 4, Col 5] IfStatement\n" +
+                        "  [Ln 1, Col 3 - Ln 1, Col 6] BooleanConstantExpression (True)\n" +
+                        "  [Ln 2, Col 2 - Ln 2, Col 5] PassStatement\n" +
+                        "  [Ln 4, Col 2 - Ln 4, Col 5] PassStatement";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 1]," +
+                              "Boolean [Ln 1, Col 3 - Ln 1, Col 6]," +
+                              "Symbol [Ln 1, Col 7 - Ln 1, Col 7]," +
+                              "Keyword [Ln 2, Col 2 - Ln 2, Col 5]," +
+                              "Keyword [Ln 3, Col 0 - Ln 3, Col 3]," +
+                              "Symbol [Ln 3, Col 4 - Ln 3, Col 4]," +
+                              "Keyword [Ln 4, Col 2 - Ln 4, Col 5]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-                "Variable [Ln 1, Col 0 - Ln 1, Col 0]," +
-                "Symbol [Ln 1, Col 1 - Ln 1, Col 1]," +
-                "Variable [Ln 1, Col 3 - Ln 1, Col 3]," +
-                "Operator [Ln 1, Col 5 - Ln 1, Col 5]," +
-                "Number [Ln 1, Col 7 - Ln 1, Col 7]," +
-                "Symbol [Ln 1, Col 8 - Ln 1, Col 8]," +
-                "Number [Ln 1, Col 10 - Ln 1, Col 10]")]
+    [Fact]
+    public void TestIfElif() {
+      string source = "if True:\n" +
+                      "  x = 1\n" +
+                      "elif False:\n" +
+                      "  x = 2\n" +
+                      "elif 1 < 2:\n" +
+                      "  x = 3\n" +
+                      "else:\n" +
+                      "  x = 4";
+      string expected = "[Ln 1, Col 0 - Ln 8, Col 6] IfStatement\n" +
+                        "  [Ln 1, Col 3 - Ln 1, Col 6] BooleanConstantExpression (True)\n" +
+                        "  [Ln 2, Col 2 - Ln 2, Col 6] AssignmentStatement\n" +
+                        "    [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (x)\n" +
+                        "    [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)\n" +
+                        "  [Ln 3, Col 0 - Ln 8, Col 6] IfStatement\n" +
+                        "    [Ln 3, Col 5 - Ln 3, Col 9] BooleanConstantExpression (False)\n" +
+                        "    [Ln 4, Col 2 - Ln 4, Col 6] AssignmentStatement\n" +
+                        "      [Ln 4, Col 2 - Ln 4, Col 2] IdentifierExpression (x)\n" +
+                        "      [Ln 4, Col 6 - Ln 4, Col 6] NumberConstantExpression (2)\n" +
+                        "    [Ln 5, Col 0 - Ln 8, Col 6] IfStatement\n" +
+                        "      [Ln 5, Col 5 - Ln 5, Col 9] ComparisonExpression\n" +
+                        "        [Ln 5, Col 5 - Ln 5, Col 5] NumberConstantExpression (1) (<)\n" +
+                        "        [Ln 5, Col 9 - Ln 5, Col 9] NumberConstantExpression (2)\n" +
+                        "      [Ln 6, Col 2 - Ln 6, Col 6] AssignmentStatement\n" +
+                        "        [Ln 6, Col 2 - Ln 6, Col 2] IdentifierExpression (x)\n" +
+                        "        [Ln 6, Col 6 - Ln 6, Col 6] NumberConstantExpression (3)\n" +
+                        "      [Ln 8, Col 2 - Ln 8, Col 6] AssignmentStatement\n" +
+                        "        [Ln 8, Col 2 - Ln 8, Col 2] IdentifierExpression (x)\n" +
+                        "        [Ln 8, Col 6 - Ln 8, Col 6] NumberConstantExpression (4)";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 1]," +
+                              "Boolean [Ln 1, Col 3 - Ln 1, Col 6]," +
+                              "Symbol [Ln 1, Col 7 - Ln 1, Col 7]," +
+                              "Variable [Ln 2, Col 2 - Ln 2, Col 2]," +
+                              "Operator [Ln 2, Col 4 - Ln 2, Col 4]," +
+                              "Number [Ln 2, Col 6 - Ln 2, Col 6]," +
+                              "Keyword [Ln 3, Col 0 - Ln 3, Col 3]," +
+                              "Boolean [Ln 3, Col 5 - Ln 3, Col 9]," +
+                              "Symbol [Ln 3, Col 10 - Ln 3, Col 10]," +
+                              "Variable [Ln 4, Col 2 - Ln 4, Col 2]," +
+                              "Operator [Ln 4, Col 4 - Ln 4, Col 4]," +
+                              "Number [Ln 4, Col 6 - Ln 4, Col 6]," +
+                              "Keyword [Ln 5, Col 0 - Ln 5, Col 3]," +
+                              "Number [Ln 5, Col 5 - Ln 5, Col 5]," +
+                              "Operator [Ln 5, Col 7 - Ln 5, Col 7]," +
+                              "Number [Ln 5, Col 9 - Ln 5, Col 9]," +
+                              "Symbol [Ln 5, Col 10 - Ln 5, Col 10]," +
+                              "Variable [Ln 6, Col 2 - Ln 6, Col 2]," +
+                              "Operator [Ln 6, Col 4 - Ln 6, Col 4]," +
+                              "Number [Ln 6, Col 6 - Ln 6, Col 6]," +
+                              "Keyword [Ln 7, Col 0 - Ln 7, Col 3]," +
+                              "Symbol [Ln 7, Col 4 - Ln 7, Col 4]," +
+                              "Variable [Ln 8, Col 2 - Ln 8, Col 2]," +
+                              "Operator [Ln 8, Col 4 - Ln 8, Col 4]," +
+                              "Number [Ln 8, Col 6 - Ln 8, Col 6]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-    [InlineData("if 1 < 2: x = 1",
+    [Fact]
+    public void TestForInList() {
+      string source = "for n in [1, 2, 3]: n";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 20] ForInStatement\n" +
+                        "  [Ln 1, Col 4 - Ln 1, Col 4] IdentifierExpression (n)\n" +
+                        "  [Ln 1, Col 9 - Ln 1, Col 17] ListExpression\n" +
+                        "    [Ln 1, Col 10 - Ln 1, Col 10] NumberConstantExpression (1)\n" +
+                        "    [Ln 1, Col 13 - Ln 1, Col 13] NumberConstantExpression (2)\n" +
+                        "    [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (3)\n" +
+                        "  [Ln 1, Col 20 - Ln 1, Col 20] ExpressionStatement\n" +
+                        "    [Ln 1, Col 20 - Ln 1, Col 20] IdentifierExpression (n)";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
+                              "Variable [Ln 1, Col 4 - Ln 1, Col 4]," +
+                              "Keyword [Ln 1, Col 6 - Ln 1, Col 7]," +
+                              "OpenBracket [Ln 1, Col 9 - Ln 1, Col 9]," +
+                              "Number [Ln 1, Col 10 - Ln 1, Col 10]," +
+                              "Symbol [Ln 1, Col 11 - Ln 1, Col 11]," +
+                              "Number [Ln 1, Col 13 - Ln 1, Col 13]," +
+                              "Symbol [Ln 1, Col 14 - Ln 1, Col 14]," +
+                              "Number [Ln 1, Col 16 - Ln 1, Col 16]," +
+                              "CloseBracket [Ln 1, Col 17 - Ln 1, Col 17]," +
+                              "Symbol [Ln 1, Col 18 - Ln 1, Col 18]," +
+                              "Variable [Ln 1, Col 20 - Ln 1, Col 20]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-                "[Ln 1, Col 0 - Ln 1, Col 14] IfStatement\n" +
-                "  [Ln 1, Col 3 - Ln 1, Col 7] ComparisonExpression\n" +
-                "    [Ln 1, Col 3 - Ln 1, Col 3] NumberConstantExpression (1) (<)\n" +
-                "    [Ln 1, Col 7 - Ln 1, Col 7] NumberConstantExpression (2)\n" +
-                "  [Ln 1, Col 10 - Ln 1, Col 14] AssignmentStatement\n" +
-                "    [Ln 1, Col 10 - Ln 1, Col 10] IdentifierExpression (x)\n" +
-                "    [Ln 1, Col 14 - Ln 1, Col 14] NumberConstantExpression (1)",
+    [Fact]
+    public void TestForInRange() {
+      string source = "for n in range(2, 10, 3): n";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 26] ForInStatement\n" +
+                        "  [Ln 1, Col 4 - Ln 1, Col 4] IdentifierExpression (n)\n" +
+                        "  [Ln 1, Col 9 - Ln 1, Col 23] CallExpression\n" +
+                        "    [Ln 1, Col 9 - Ln 1, Col 13] IdentifierExpression (range)\n" +
+                        "    [Ln 1, Col 15 - Ln 1, Col 15] NumberConstantExpression (2)\n" +
+                        "    [Ln 1, Col 18 - Ln 1, Col 19] NumberConstantExpression (10)\n" +
+                        "    [Ln 1, Col 22 - Ln 1, Col 22] NumberConstantExpression (3)\n" +
+                        "  [Ln 1, Col 26 - Ln 1, Col 26] ExpressionStatement\n" +
+                        "    [Ln 1, Col 26 - Ln 1, Col 26] IdentifierExpression (n)";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
+                              "Variable [Ln 1, Col 4 - Ln 1, Col 4]," +
+                              "Keyword [Ln 1, Col 6 - Ln 1, Col 7]," +
+                              "Variable [Ln 1, Col 9 - Ln 1, Col 13]," +
+                              "OpenParenthesis [Ln 1, Col 14 - Ln 1, Col 14]," +
+                              "Number [Ln 1, Col 15 - Ln 1, Col 15]," +
+                              "Symbol [Ln 1, Col 16 - Ln 1, Col 16]," +
+                              "Number [Ln 1, Col 18 - Ln 1, Col 19]," +
+                              "Symbol [Ln 1, Col 20 - Ln 1, Col 20]," +
+                              "Number [Ln 1, Col 22 - Ln 1, Col 22]," +
+                              "CloseParenthesis [Ln 1, Col 23 - Ln 1, Col 23]," +
+                              "Symbol [Ln 1, Col 24 - Ln 1, Col 24]," +
+                              "Variable [Ln 1, Col 26 - Ln 1, Col 26]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 1]," +
-                "Number [Ln 1, Col 3 - Ln 1, Col 3]," +
-                "Operator [Ln 1, Col 5 - Ln 1, Col 5]," +
-                "Number [Ln 1, Col 7 - Ln 1, Col 7]," +
-                "Symbol [Ln 1, Col 8 - Ln 1, Col 8]," +
-                "Variable [Ln 1, Col 10 - Ln 1, Col 10]," +
-                "Operator [Ln 1, Col 12 - Ln 1, Col 12]," +
-                "Number [Ln 1, Col 14 - Ln 1, Col 14]")]
+    [Fact]
+    public void TestWhile() {
+      string source = "while True: x = 1";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 16] WhileStatement\n" +
+                        "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)\n" +
+                        "  [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement\n" +
+                        "    [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x)\n" +
+                        "    [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 4]," +
+                              "Boolean [Ln 1, Col 6 - Ln 1, Col 9]," +
+                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
+                              "Variable [Ln 1, Col 12 - Ln 1, Col 12]," +
+                              "Operator [Ln 1, Col 14 - Ln 1, Col 14]," +
+                              "Number [Ln 1, Col 16 - Ln 1, Col 16]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-    [InlineData("if True:\n" +
-                "  x = 1\n" +
-                "else:\n" +
-                "  x = 2",
+    [Fact]
+    public void TestWhileWithBody() {
+      string source = "while True:\n" +
+                      "  x = 1\n" +
+                      "  y = 2";
+      string expected = "[Ln 1, Col 0 - Ln 3, Col 6] WhileStatement\n" +
+                        "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)\n" +
+                        "  [Ln 2, Col 2 - Ln 3, Col 6] BlockStatement\n" +
+                        "    [Ln 2, Col 2 - Ln 2, Col 6] AssignmentStatement\n" +
+                        "      [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (x)\n" +
+                        "      [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)\n" +
+                        "    [Ln 3, Col 2 - Ln 3, Col 6] AssignmentStatement\n" +
+                        "      [Ln 3, Col 2 - Ln 3, Col 2] IdentifierExpression (y)\n" +
+                        "      [Ln 3, Col 6 - Ln 3, Col 6] NumberConstantExpression (2)";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 4]," +
+                              "Boolean [Ln 1, Col 6 - Ln 1, Col 9]," +
+                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
+                              "Variable [Ln 2, Col 2 - Ln 2, Col 2]," +
+                              "Operator [Ln 2, Col 4 - Ln 2, Col 4]," +
+                              "Number [Ln 2, Col 6 - Ln 2, Col 6]," +
+                              "Variable [Ln 3, Col 2 - Ln 3, Col 2]," +
+                              "Operator [Ln 3, Col 4 - Ln 3, Col 4]," +
+                              "Number [Ln 3, Col 6 - Ln 3, Col 6]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-                "[Ln 1, Col 0 - Ln 4, Col 6] IfStatement\n" +
-                "  [Ln 1, Col 3 - Ln 1, Col 6] BooleanConstantExpression (True)\n" +
-                "  [Ln 2, Col 2 - Ln 2, Col 6] AssignmentStatement\n" +
-                "    [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (x)\n" +
-                "    [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)\n" +
-                "  [Ln 4, Col 2 - Ln 4, Col 6] AssignmentStatement\n" +
-                "    [Ln 4, Col 2 - Ln 4, Col 2] IdentifierExpression (x)\n" +
-                "    [Ln 4, Col 6 - Ln 4, Col 6] NumberConstantExpression (2)",
+    [Fact]
+    public void TestWhileWithSimpleStatementsBody() {
+      string source = "while True: x = 1; y = 2";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 23] WhileStatement\n" +
+                        "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)\n" +
+                        "  [Ln 1, Col 12 - Ln 1, Col 23] BlockStatement\n" +
+                        "    [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement\n" +
+                        "      [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x)\n" +
+                        "      [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)\n" +
+                        "    [Ln 1, Col 19 - Ln 1, Col 23] AssignmentStatement\n" +
+                        "      [Ln 1, Col 19 - Ln 1, Col 19] IdentifierExpression (y)\n" +
+                        "      [Ln 1, Col 23 - Ln 1, Col 23] NumberConstantExpression (2)";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 4]," +
+                              "Boolean [Ln 1, Col 6 - Ln 1, Col 9]," +
+                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
+                              "Variable [Ln 1, Col 12 - Ln 1, Col 12]," +
+                              "Operator [Ln 1, Col 14 - Ln 1, Col 14]," +
+                              "Number [Ln 1, Col 16 - Ln 1, Col 16]," +
+                              "Symbol [Ln 1, Col 17 - Ln 1, Col 17]," +
+                              "Variable [Ln 1, Col 19 - Ln 1, Col 19]," +
+                              "Operator [Ln 1, Col 21 - Ln 1, Col 21]," +
+                              "Number [Ln 1, Col 23 - Ln 1, Col 23]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 1]," +
-                "Boolean [Ln 1, Col 3 - Ln 1, Col 6]," +
-                "Symbol [Ln 1, Col 7 - Ln 1, Col 7]," +
-                "Variable [Ln 2, Col 2 - Ln 2, Col 2]," +
-                "Operator [Ln 2, Col 4 - Ln 2, Col 4]," +
-                "Number [Ln 2, Col 6 - Ln 2, Col 6]," +
-                "Keyword [Ln 3, Col 0 - Ln 3, Col 3]," +
-                "Symbol [Ln 3, Col 4 - Ln 3, Col 4]," +
-                "Variable [Ln 4, Col 2 - Ln 4, Col 2]," +
-                "Operator [Ln 4, Col 4 - Ln 4, Col 4]," +
-                "Number [Ln 4, Col 6 - Ln 4, Col 6]")]
+    [Fact]
+    public void TestWhileWithSimpleStatementsAndFinalCommaBody() {
+      string source = "while True: x = 1; y = 2;";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 23] WhileStatement\n" +
+                        "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)\n" +
+                        "  [Ln 1, Col 12 - Ln 1, Col 23] BlockStatement\n" +
+                        "    [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement\n" +
+                        "      [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x)\n" +
+                        "      [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)\n" +
+                        "    [Ln 1, Col 19 - Ln 1, Col 23] AssignmentStatement\n" +
+                        "      [Ln 1, Col 19 - Ln 1, Col 19] IdentifierExpression (y)\n" +
+                        "      [Ln 1, Col 23 - Ln 1, Col 23] NumberConstantExpression (2)";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 4]," +
+                              "Boolean [Ln 1, Col 6 - Ln 1, Col 9]," +
+                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
+                              "Variable [Ln 1, Col 12 - Ln 1, Col 12]," +
+                              "Operator [Ln 1, Col 14 - Ln 1, Col 14]," +
+                              "Number [Ln 1, Col 16 - Ln 1, Col 16]," +
+                              "Symbol [Ln 1, Col 17 - Ln 1, Col 17]," +
+                              "Variable [Ln 1, Col 19 - Ln 1, Col 19]," +
+                              "Operator [Ln 1, Col 21 - Ln 1, Col 21]," +
+                              "Number [Ln 1, Col 23 - Ln 1, Col 23]," +
+                              "Symbol [Ln 1, Col 24 - Ln 1, Col 24]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-    [InlineData("if True:\n" +
-                "  x = 1\n" +
-                "elif False:\n" +
-                "  x = 2\n" +
-                "elif 1 < 2:\n" +
-                "  x = 3\n" +
-                "else:\n" +
-                "  x = 4",
+    [Fact]
+    public void TestFuncWithoutReturn() {
+      string source = "def func(): x = 1";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 16] FuncDefStatement (func)\n" +
+                        "  [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement\n" +
+                        "    [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x)\n" +
+                        "    [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
+                              "Function [Ln 1, Col 4 - Ln 1, Col 7]," +
+                              "OpenParenthesis [Ln 1, Col 8 - Ln 1, Col 8]," +
+                              "CloseParenthesis [Ln 1, Col 9 - Ln 1, Col 9]," +
+                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
+                              "Variable [Ln 1, Col 12 - Ln 1, Col 12]," +
+                              "Operator [Ln 1, Col 14 - Ln 1, Col 14]," +
+                              "Number [Ln 1, Col 16 - Ln 1, Col 16]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-                "[Ln 1, Col 0 - Ln 8, Col 6] IfStatement\n" +
-                "  [Ln 1, Col 3 - Ln 1, Col 6] BooleanConstantExpression (True)\n" +
-                "  [Ln 2, Col 2 - Ln 2, Col 6] AssignmentStatement\n" +
-                "    [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (x)\n" +
-                "    [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)\n" +
-                "  [Ln 3, Col 0 - Ln 8, Col 6] IfStatement\n" +
-                "    [Ln 3, Col 5 - Ln 3, Col 9] BooleanConstantExpression (False)\n" +
-                "    [Ln 4, Col 2 - Ln 4, Col 6] AssignmentStatement\n" +
-                "      [Ln 4, Col 2 - Ln 4, Col 2] IdentifierExpression (x)\n" +
-                "      [Ln 4, Col 6 - Ln 4, Col 6] NumberConstantExpression (2)\n" +
-                "    [Ln 5, Col 0 - Ln 8, Col 6] IfStatement\n" +
-                "      [Ln 5, Col 5 - Ln 5, Col 9] ComparisonExpression\n" +
-                "        [Ln 5, Col 5 - Ln 5, Col 5] NumberConstantExpression (1) (<)\n" +
-                "        [Ln 5, Col 9 - Ln 5, Col 9] NumberConstantExpression (2)\n" +
-                "      [Ln 6, Col 2 - Ln 6, Col 6] AssignmentStatement\n" +
-                "        [Ln 6, Col 2 - Ln 6, Col 2] IdentifierExpression (x)\n" +
-                "        [Ln 6, Col 6 - Ln 6, Col 6] NumberConstantExpression (3)\n" +
-                "      [Ln 8, Col 2 - Ln 8, Col 6] AssignmentStatement\n" +
-                "        [Ln 8, Col 2 - Ln 8, Col 2] IdentifierExpression (x)\n" +
-                "        [Ln 8, Col 6 - Ln 8, Col 6] NumberConstantExpression (4)",
+    [Fact]
+    public void TestEmptyReturn() {
+      string source = "def func(): return";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 17] FuncDefStatement (func)\n" +
+                        "  [Ln 1, Col 12 - Ln 1, Col 17] ReturnStatement";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
+                              "Function [Ln 1, Col 4 - Ln 1, Col 7]," +
+                              "OpenParenthesis [Ln 1, Col 8 - Ln 1, Col 8]," +
+                              "CloseParenthesis [Ln 1, Col 9 - Ln 1, Col 9]," +
+                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
+                              "Keyword [Ln 1, Col 12 - Ln 1, Col 17]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 1]," +
-                "Boolean [Ln 1, Col 3 - Ln 1, Col 6]," +
-                "Symbol [Ln 1, Col 7 - Ln 1, Col 7]," +
-                "Variable [Ln 2, Col 2 - Ln 2, Col 2]," +
-                "Operator [Ln 2, Col 4 - Ln 2, Col 4]," +
-                "Number [Ln 2, Col 6 - Ln 2, Col 6]," +
-                "Keyword [Ln 3, Col 0 - Ln 3, Col 3]," +
-                "Boolean [Ln 3, Col 5 - Ln 3, Col 9]," +
-                "Symbol [Ln 3, Col 10 - Ln 3, Col 10]," +
-                "Variable [Ln 4, Col 2 - Ln 4, Col 2]," +
-                "Operator [Ln 4, Col 4 - Ln 4, Col 4]," +
-                "Number [Ln 4, Col 6 - Ln 4, Col 6]," +
-                "Keyword [Ln 5, Col 0 - Ln 5, Col 3]," +
-                "Number [Ln 5, Col 5 - Ln 5, Col 5]," +
-                "Operator [Ln 5, Col 7 - Ln 5, Col 7]," +
-                "Number [Ln 5, Col 9 - Ln 5, Col 9]," +
-                "Symbol [Ln 5, Col 10 - Ln 5, Col 10]," +
-                "Variable [Ln 6, Col 2 - Ln 6, Col 2]," +
-                "Operator [Ln 6, Col 4 - Ln 6, Col 4]," +
-                "Number [Ln 6, Col 6 - Ln 6, Col 6]," +
-                "Keyword [Ln 7, Col 0 - Ln 7, Col 3]," +
-                "Symbol [Ln 7, Col 4 - Ln 7, Col 4]," +
-                "Variable [Ln 8, Col 2 - Ln 8, Col 2]," +
-                "Operator [Ln 8, Col 4 - Ln 8, Col 4]," +
-                "Number [Ln 8, Col 6 - Ln 8, Col 6]")]
+    [Fact]
+    public void TestMultipleReturn() {
+      string source = "def func():\n" +
+                      "  return 1, 2, 3";
+      string expected = "[Ln 1, Col 0 - Ln 2, Col 15] FuncDefStatement (func)\n" +
+                        "  [Ln 2, Col 2 - Ln 2, Col 15] ReturnStatement\n" +
+                        "    [Ln 2, Col 9 - Ln 2, Col 9] NumberConstantExpression (1)\n" +
+                        "    [Ln 2, Col 12 - Ln 2, Col 12] NumberConstantExpression (2)\n" +
+                        "    [Ln 2, Col 15 - Ln 2, Col 15] NumberConstantExpression (3)";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
+                              "Function [Ln 1, Col 4 - Ln 1, Col 7]," +
+                              "OpenParenthesis [Ln 1, Col 8 - Ln 1, Col 8]," +
+                              "CloseParenthesis [Ln 1, Col 9 - Ln 1, Col 9]," +
+                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
+                              "Keyword [Ln 2, Col 2 - Ln 2, Col 7]," +
+                              "Number [Ln 2, Col 9 - Ln 2, Col 9]," +
+                              "Symbol [Ln 2, Col 10 - Ln 2, Col 10]," +
+                              "Number [Ln 2, Col 12 - Ln 2, Col 12]," +
+                              "Symbol [Ln 2, Col 13 - Ln 2, Col 13]," +
+                              "Number [Ln 2, Col 15 - Ln 2, Col 15]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-    [InlineData("while True: x = 1",
+    [Fact]
+    public void TestReturnVariable() {
+      string source = "def add(a, b):\n" +
+                      "  c = a + b\n" +
+                      "  return c";
+      string expected = "[Ln 1, Col 0 - Ln 3, Col 9] FuncDefStatement (add:a,b)\n" +
+                        "  [Ln 2, Col 2 - Ln 3, Col 9] BlockStatement\n" +
+                        "    [Ln 2, Col 2 - Ln 2, Col 10] AssignmentStatement\n" +
+                        "      [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (c)\n" +
+                        "      [Ln 2, Col 6 - Ln 2, Col 10] BinaryExpression (+)\n" +
+                        "        [Ln 2, Col 6 - Ln 2, Col 6] IdentifierExpression (a)\n" +
+                        "        [Ln 2, Col 10 - Ln 2, Col 10] IdentifierExpression (b)\n" +
+                        "    [Ln 3, Col 2 - Ln 3, Col 9] ReturnStatement\n" +
+                        "      [Ln 3, Col 9 - Ln 3, Col 9] IdentifierExpression (c)";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
+                              "Function [Ln 1, Col 4 - Ln 1, Col 6]," +
+                              "OpenParenthesis [Ln 1, Col 7 - Ln 1, Col 7]," +
+                              "Parameter [Ln 1, Col 8 - Ln 1, Col 8]," +
+                              "Symbol [Ln 1, Col 9 - Ln 1, Col 9]," +
+                              "Parameter [Ln 1, Col 11 - Ln 1, Col 11]," +
+                              "CloseParenthesis [Ln 1, Col 12 - Ln 1, Col 12]," +
+                              "Symbol [Ln 1, Col 13 - Ln 1, Col 13]," +
+                              "Variable [Ln 2, Col 2 - Ln 2, Col 2]," +
+                              "Operator [Ln 2, Col 4 - Ln 2, Col 4]," +
+                              "Variable [Ln 2, Col 6 - Ln 2, Col 6]," +
+                              "Operator [Ln 2, Col 8 - Ln 2, Col 8]," +
+                              "Variable [Ln 2, Col 10 - Ln 2, Col 10]," +
+                              "Keyword [Ln 3, Col 2 - Ln 3, Col 7]," +
+                              "Variable [Ln 3, Col 9 - Ln 3, Col 9]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-                "[Ln 1, Col 0 - Ln 1, Col 16] WhileStatement\n" +
-                "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)\n" +
-                "  [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement\n" +
-                "    [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x)\n" +
-                "    [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)",
+    [Fact]
+    public void TestReturnBinary() {
+      string source = "def add(a, b):\n" +
+                      "  return a + b";
+      string expected = "[Ln 1, Col 0 - Ln 2, Col 13] FuncDefStatement (add:a,b)\n" +
+                        "  [Ln 2, Col 2 - Ln 2, Col 13] ReturnStatement\n" +
+                        "    [Ln 2, Col 9 - Ln 2, Col 13] BinaryExpression (+)\n" +
+                        "      [Ln 2, Col 9 - Ln 2, Col 9] IdentifierExpression (a)\n" +
+                        "      [Ln 2, Col 13 - Ln 2, Col 13] IdentifierExpression (b)";
+      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
+                              "Function [Ln 1, Col 4 - Ln 1, Col 6]," +
+                              "OpenParenthesis [Ln 1, Col 7 - Ln 1, Col 7]," +
+                              "Parameter [Ln 1, Col 8 - Ln 1, Col 8]," +
+                              "Symbol [Ln 1, Col 9 - Ln 1, Col 9]," +
+                              "Parameter [Ln 1, Col 11 - Ln 1, Col 11]," +
+                              "CloseParenthesis [Ln 1, Col 12 - Ln 1, Col 12]," +
+                              "Symbol [Ln 1, Col 13 - Ln 1, Col 13]," +
+                              "Keyword [Ln 2, Col 2 - Ln 2, Col 7]," +
+                              "Variable [Ln 2, Col 9 - Ln 2, Col 9]," +
+                              "Operator [Ln 2, Col 11 - Ln 2, Col 11]," +
+                              "Variable [Ln 2, Col 13 - Ln 2, Col 13]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
 
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 4]," +
-                "Boolean [Ln 1, Col 6 - Ln 1, Col 9]," +
-                "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                "Variable [Ln 1, Col 12 - Ln 1, Col 12]," +
-                "Operator [Ln 1, Col 14 - Ln 1, Col 14]," +
-                "Number [Ln 1, Col 16 - Ln 1, Col 16]")]
-
-    [InlineData("while True:\n" +
-                "  x = 1\n" +
-                "  y = 2",
-
-                "[Ln 1, Col 0 - Ln 3, Col 6] WhileStatement\n" +
-                "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)\n" +
-                "  [Ln 2, Col 2 - Ln 3, Col 6] BlockStatement\n" +
-                "    [Ln 2, Col 2 - Ln 2, Col 6] AssignmentStatement\n" +
-                "      [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (x)\n" +
-                "      [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)\n" +
-                "    [Ln 3, Col 2 - Ln 3, Col 6] AssignmentStatement\n" +
-                "      [Ln 3, Col 2 - Ln 3, Col 2] IdentifierExpression (y)\n" +
-                "      [Ln 3, Col 6 - Ln 3, Col 6] NumberConstantExpression (2)",
-
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 4]," +
-                "Boolean [Ln 1, Col 6 - Ln 1, Col 9]," +
-                "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                "Variable [Ln 2, Col 2 - Ln 2, Col 2]," +
-                "Operator [Ln 2, Col 4 - Ln 2, Col 4]," +
-                "Number [Ln 2, Col 6 - Ln 2, Col 6]," +
-                "Variable [Ln 3, Col 2 - Ln 3, Col 2]," +
-                "Operator [Ln 3, Col 4 - Ln 3, Col 4]," +
-                "Number [Ln 3, Col 6 - Ln 3, Col 6]")]
-
-    [InlineData("while True: x = 1; y = 2",
-
-                "[Ln 1, Col 0 - Ln 1, Col 23] WhileStatement\n" +
-                "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)\n" +
-                "  [Ln 1, Col 12 - Ln 1, Col 23] BlockStatement\n" +
-                "    [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement\n" +
-                "      [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x)\n" +
-                "      [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)\n" +
-                "    [Ln 1, Col 19 - Ln 1, Col 23] AssignmentStatement\n" +
-                "      [Ln 1, Col 19 - Ln 1, Col 19] IdentifierExpression (y)\n" +
-                "      [Ln 1, Col 23 - Ln 1, Col 23] NumberConstantExpression (2)",
-
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 4]," +
-                "Boolean [Ln 1, Col 6 - Ln 1, Col 9]," +
-                "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                "Variable [Ln 1, Col 12 - Ln 1, Col 12]," +
-                "Operator [Ln 1, Col 14 - Ln 1, Col 14]," +
-                "Number [Ln 1, Col 16 - Ln 1, Col 16]," +
-                "Symbol [Ln 1, Col 17 - Ln 1, Col 17]," +
-                "Variable [Ln 1, Col 19 - Ln 1, Col 19]," +
-                "Operator [Ln 1, Col 21 - Ln 1, Col 21]," +
-                "Number [Ln 1, Col 23 - Ln 1, Col 23]")]
-
-    [InlineData("while True: x = 1; y = 2;",
-
-                "[Ln 1, Col 0 - Ln 1, Col 23] WhileStatement\n" +
-                "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)\n" +
-                "  [Ln 1, Col 12 - Ln 1, Col 23] BlockStatement\n" +
-                "    [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement\n" +
-                "      [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x)\n" +
-                "      [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)\n" +
-                "    [Ln 1, Col 19 - Ln 1, Col 23] AssignmentStatement\n" +
-                "      [Ln 1, Col 19 - Ln 1, Col 19] IdentifierExpression (y)\n" +
-                "      [Ln 1, Col 23 - Ln 1, Col 23] NumberConstantExpression (2)",
-
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 4]," +
-                "Boolean [Ln 1, Col 6 - Ln 1, Col 9]," +
-                "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                "Variable [Ln 1, Col 12 - Ln 1, Col 12]," +
-                "Operator [Ln 1, Col 14 - Ln 1, Col 14]," +
-                "Number [Ln 1, Col 16 - Ln 1, Col 16]," +
-                "Symbol [Ln 1, Col 17 - Ln 1, Col 17]," +
-                "Variable [Ln 1, Col 19 - Ln 1, Col 19]," +
-                "Operator [Ln 1, Col 21 - Ln 1, Col 21]," +
-                "Number [Ln 1, Col 23 - Ln 1, Col 23]," +
-                "Symbol [Ln 1, Col 24 - Ln 1, Col 24]")]
-
-    [InlineData("def func(): x = 1",
-
-                "[Ln 1, Col 0 - Ln 1, Col 16] FuncDefStatement (func)\n" +
-                "  [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement\n" +
-                "    [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x)\n" +
-                "    [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)",
-
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                "Function [Ln 1, Col 4 - Ln 1, Col 7]," +
-                "OpenParenthesis [Ln 1, Col 8 - Ln 1, Col 8]," +
-                "CloseParenthesis [Ln 1, Col 9 - Ln 1, Col 9]," +
-                "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                "Variable [Ln 1, Col 12 - Ln 1, Col 12]," +
-                "Operator [Ln 1, Col 14 - Ln 1, Col 14]," +
-                "Number [Ln 1, Col 16 - Ln 1, Col 16]")]
-
-    [InlineData("def add(a, b):\n" +
-                "  return a + b",
-
-                "[Ln 1, Col 0 - Ln 2, Col 13] FuncDefStatement (add:a,b)\n" +
-                "  [Ln 2, Col 2 - Ln 2, Col 13] ReturnStatement\n" +
-                "    [Ln 2, Col 9 - Ln 2, Col 13] BinaryExpression (+)\n" +
-                "      [Ln 2, Col 9 - Ln 2, Col 9] IdentifierExpression (a)\n" +
-                "      [Ln 2, Col 13 - Ln 2, Col 13] IdentifierExpression (b)",
-
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                "Function [Ln 1, Col 4 - Ln 1, Col 6]," +
-                "OpenParenthesis [Ln 1, Col 7 - Ln 1, Col 7]," +
-                "Parameter [Ln 1, Col 8 - Ln 1, Col 8]," +
-                "Symbol [Ln 1, Col 9 - Ln 1, Col 9]," +
-                "Parameter [Ln 1, Col 11 - Ln 1, Col 11]," +
-                "CloseParenthesis [Ln 1, Col 12 - Ln 1, Col 12]," +
-                "Symbol [Ln 1, Col 13 - Ln 1, Col 13]," +
-                "Keyword [Ln 2, Col 2 - Ln 2, Col 7]," +
-                "Variable [Ln 2, Col 9 - Ln 2, Col 9]," +
-                "Operator [Ln 2, Col 11 - Ln 2, Col 11]," +
-                "Variable [Ln 2, Col 13 - Ln 2, Col 13]")]
-
-    [InlineData("def add(a, b):\n" +
-                "  c = a + b\n" +
-                "  return c",
-
-                "[Ln 1, Col 0 - Ln 3, Col 9] FuncDefStatement (add:a,b)\n" +
-                "  [Ln 2, Col 2 - Ln 3, Col 9] BlockStatement\n" +
-                "    [Ln 2, Col 2 - Ln 2, Col 10] AssignmentStatement\n" +
-                "      [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (c)\n" +
-                "      [Ln 2, Col 6 - Ln 2, Col 10] BinaryExpression (+)\n" +
-                "        [Ln 2, Col 6 - Ln 2, Col 6] IdentifierExpression (a)\n" +
-                "        [Ln 2, Col 10 - Ln 2, Col 10] IdentifierExpression (b)\n" +
-                "    [Ln 3, Col 2 - Ln 3, Col 9] ReturnStatement\n" +
-                "      [Ln 3, Col 9 - Ln 3, Col 9] IdentifierExpression (c)",
-
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                "Function [Ln 1, Col 4 - Ln 1, Col 6]," +
-                "OpenParenthesis [Ln 1, Col 7 - Ln 1, Col 7]," +
-                "Parameter [Ln 1, Col 8 - Ln 1, Col 8]," +
-                "Symbol [Ln 1, Col 9 - Ln 1, Col 9]," +
-                "Parameter [Ln 1, Col 11 - Ln 1, Col 11]," +
-                "CloseParenthesis [Ln 1, Col 12 - Ln 1, Col 12]," +
-                "Symbol [Ln 1, Col 13 - Ln 1, Col 13]," +
-                "Variable [Ln 2, Col 2 - Ln 2, Col 2]," +
-                "Operator [Ln 2, Col 4 - Ln 2, Col 4]," +
-                "Variable [Ln 2, Col 6 - Ln 2, Col 6]," +
-                "Operator [Ln 2, Col 8 - Ln 2, Col 8]," +
-                "Variable [Ln 2, Col 10 - Ln 2, Col 10]," +
-                "Keyword [Ln 3, Col 2 - Ln 3, Col 7]," +
-                "Variable [Ln 3, Col 9 - Ln 3, Col 9]")]
-
-    [InlineData("def func():\n" +
-                "  return 1, 2, 3",
-
-                "[Ln 1, Col 0 - Ln 2, Col 15] FuncDefStatement (func)\n" +
-                "  [Ln 2, Col 2 - Ln 2, Col 15] ReturnStatement\n" +
-                "    [Ln 2, Col 9 - Ln 2, Col 9] NumberConstantExpression (1)\n" +
-                "    [Ln 2, Col 12 - Ln 2, Col 12] NumberConstantExpression (2)\n" +
-                "    [Ln 2, Col 15 - Ln 2, Col 15] NumberConstantExpression (3)",
-
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                "Function [Ln 1, Col 4 - Ln 1, Col 7]," +
-                "OpenParenthesis [Ln 1, Col 8 - Ln 1, Col 8]," +
-                "CloseParenthesis [Ln 1, Col 9 - Ln 1, Col 9]," +
-                "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                "Keyword [Ln 2, Col 2 - Ln 2, Col 7]," +
-                "Number [Ln 2, Col 9 - Ln 2, Col 9]," +
-                "Symbol [Ln 2, Col 10 - Ln 2, Col 10]," +
-                "Number [Ln 2, Col 12 - Ln 2, Col 12]," +
-                "Symbol [Ln 2, Col 13 - Ln 2, Col 13]," +
-                "Number [Ln 2, Col 15 - Ln 2, Col 15]")]
-
-    [InlineData("for n in [1, 2, 3]: n",
-
-                "[Ln 1, Col 0 - Ln 1, Col 20] ForInStatement\n" +
-                "  [Ln 1, Col 4 - Ln 1, Col 4] IdentifierExpression (n)\n" +
-                "  [Ln 1, Col 9 - Ln 1, Col 17] ListExpression\n" +
-                "    [Ln 1, Col 10 - Ln 1, Col 10] NumberConstantExpression (1)\n" +
-                "    [Ln 1, Col 13 - Ln 1, Col 13] NumberConstantExpression (2)\n" +
-                "    [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (3)\n" +
-                "  [Ln 1, Col 20 - Ln 1, Col 20] ExpressionStatement\n" +
-                "    [Ln 1, Col 20 - Ln 1, Col 20] IdentifierExpression (n)",
-
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                "Variable [Ln 1, Col 4 - Ln 1, Col 4]," +
-                "Keyword [Ln 1, Col 6 - Ln 1, Col 7]," +
-                "OpenBracket [Ln 1, Col 9 - Ln 1, Col 9]," +
-                "Number [Ln 1, Col 10 - Ln 1, Col 10]," +
-                "Symbol [Ln 1, Col 11 - Ln 1, Col 11]," +
-                "Number [Ln 1, Col 13 - Ln 1, Col 13]," +
-                "Symbol [Ln 1, Col 14 - Ln 1, Col 14]," +
-                "Number [Ln 1, Col 16 - Ln 1, Col 16]," +
-                "CloseBracket [Ln 1, Col 17 - Ln 1, Col 17]," +
-                "Symbol [Ln 1, Col 18 - Ln 1, Col 18]," +
-                "Variable [Ln 1, Col 20 - Ln 1, Col 20]")]
-
-    [InlineData("for n in range(2, 10, 3): n",
-
-                "[Ln 1, Col 0 - Ln 1, Col 26] ForInStatement\n" +
-                "  [Ln 1, Col 4 - Ln 1, Col 4] IdentifierExpression (n)\n" +
-                "  [Ln 1, Col 9 - Ln 1, Col 23] CallExpression\n" +
-                "    [Ln 1, Col 9 - Ln 1, Col 13] IdentifierExpression (range)\n" +
-                "    [Ln 1, Col 15 - Ln 1, Col 15] NumberConstantExpression (2)\n" +
-                "    [Ln 1, Col 18 - Ln 1, Col 19] NumberConstantExpression (10)\n" +
-                "    [Ln 1, Col 22 - Ln 1, Col 22] NumberConstantExpression (3)\n" +
-                "  [Ln 1, Col 26 - Ln 1, Col 26] ExpressionStatement\n" +
-                "    [Ln 1, Col 26 - Ln 1, Col 26] IdentifierExpression (n)",
-
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                "Variable [Ln 1, Col 4 - Ln 1, Col 4]," +
-                "Keyword [Ln 1, Col 6 - Ln 1, Col 7]," +
-                "Variable [Ln 1, Col 9 - Ln 1, Col 13]," +
-                "OpenParenthesis [Ln 1, Col 14 - Ln 1, Col 14]," +
-                "Number [Ln 1, Col 15 - Ln 1, Col 15]," +
-                "Symbol [Ln 1, Col 16 - Ln 1, Col 16]," +
-                "Number [Ln 1, Col 18 - Ln 1, Col 19]," +
-                "Symbol [Ln 1, Col 20 - Ln 1, Col 20]," +
-                "Number [Ln 1, Col 22 - Ln 1, Col 22]," +
-                "CloseParenthesis [Ln 1, Col 23 - Ln 1, Col 23]," +
-                "Symbol [Ln 1, Col 24 - Ln 1, Col 24]," +
-                "Variable [Ln 1, Col 26 - Ln 1, Col 26]")]
-
-    [InlineData("if True:\n" +
-                "  pass\n" +
-                "else:\n" +
-                "  pass",
-
-                "[Ln 1, Col 0 - Ln 4, Col 5] IfStatement\n" +
-                "  [Ln 1, Col 3 - Ln 1, Col 6] BooleanConstantExpression (True)\n" +
-                "  [Ln 2, Col 2 - Ln 2, Col 5] PassStatement\n" +
-                "  [Ln 4, Col 2 - Ln 4, Col 5] PassStatement",
-
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 1]," +
-                "Boolean [Ln 1, Col 3 - Ln 1, Col 6]," +
-                "Symbol [Ln 1, Col 7 - Ln 1, Col 7]," +
-                "Keyword [Ln 2, Col 2 - Ln 2, Col 5]," +
-                "Keyword [Ln 3, Col 0 - Ln 3, Col 3]," +
-                "Symbol [Ln 3, Col 4 - Ln 3, Col 4]," +
-                "Keyword [Ln 4, Col 2 - Ln 4, Col 5]")]
-
-    [InlineData("str = 'test string'",
-
-                "[Ln 1, Col 0 - Ln 1, Col 18] AssignmentStatement\n" +
-                "  [Ln 1, Col 0 - Ln 1, Col 2] IdentifierExpression (str)\n" +
-                "  [Ln 1, Col 6 - Ln 1, Col 18] StringConstantExpression (test string)",
-
-                "Variable [Ln 1, Col 0 - Ln 1, Col 2]," +
-                "Operator [Ln 1, Col 4 - Ln 1, Col 4]," +
-                "String [Ln 1, Col 6 - Ln 1, Col 18]")]
-
-    [InlineData("str = 'a' \"b\" 'c'",
-
-                "[Ln 1, Col 0 - Ln 1, Col 16] AssignmentStatement\n" +
-                "  [Ln 1, Col 0 - Ln 1, Col 2] IdentifierExpression (str)\n" +
-                "  [Ln 1, Col 6 - Ln 1, Col 16] StringConstantExpression (abc)",
-
-                "Variable [Ln 1, Col 0 - Ln 1, Col 2]," +
-                "Operator [Ln 1, Col 4 - Ln 1, Col 4]," +
-                "String [Ln 1, Col 6 - Ln 1, Col 8]," +
-                "String [Ln 1, Col 10 - Ln 1, Col 12]," +
-                "String [Ln 1, Col 14 - Ln 1, Col 16]")]
-
-    [InlineData("def func(): return",
-
-                "[Ln 1, Col 0 - Ln 1, Col 17] FuncDefStatement (func)\n" +
-                "  [Ln 1, Col 12 - Ln 1, Col 17] ReturnStatement",
-
-                "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                "Function [Ln 1, Col 4 - Ln 1, Col 7]," +
-                "OpenParenthesis [Ln 1, Col 8 - Ln 1, Col 8]," +
-                "CloseParenthesis [Ln 1, Col 9 - Ln 1, Col 9]," +
-                "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                "Keyword [Ln 1, Col 12 - Ln 1, Col 17]")]
-    public void TestPythonParser(string input, string expectedAst, string expectedTokens) {
-      Assert.True(_parser.Parse(input, "", _collection, out AstNode node,
-                                out IReadOnlyList<TokenInfo> tokens));
+    private static void TestPythonParser(string input, string expected, string expectedTokens) {
+      var collection = new DiagnosticCollection();
+      Assert.True(new SeedPython().Parse(input, "", collection, out AstNode node,
+                                         out IReadOnlyList<TokenInfo> tokens));
       Assert.NotNull(node);
-      Assert.Empty(_collection.Diagnostics);
-      Assert.Equal(expectedAst, node.ToString());
+      Assert.Empty(collection.Diagnostics);
+      Assert.Equal(expected, node.ToString());
       Assert.Equal(expectedTokens, string.Join(",", tokens.Select(token => token.ToString())));
     }
   }

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonStatementTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonStatementTests.cs
@@ -21,6 +21,14 @@ using Xunit;
 namespace SeedLang.X.Tests {
   public class SeedPythonStatementTests {
     [Fact]
+    public void TestOneLineComments() {
+      string source = "# comment\n";
+      string expected = "[Ln 1, Col 9 - Ln 1, Col 9] BlockStatement";
+      string expectedTokens = "";
+      TestPythonParser(source, expected, expectedTokens);
+    }
+
+    [Fact]
     public void TestComments() {
       string source = "# comment\nprint(1)";
       string expected = "[Ln 2, Col 0 - Ln 2, Col 7] ExpressionStatement\n" +

--- a/examples/seedpython/scripts/string.py
+++ b/examples/seedpython/scripts/string.py
@@ -1,8 +1,6 @@
-print('TODO: Fix the parsing error that comments cannot be the first line of scripts.')
-
-# The language doesn't support raw string like r"raw string".
-# The language doesn't support unicode string like u"unicode string".
-# The language doesn't support string templates like "...%()...", "...{}..." or
+# 1) SeedLang doesn't support raw string like r"raw string".
+# 2) SeedLang doesn't support unicode string like u"unicode string".
+# 3) SeedLang doesn't support string templates like "...%()...", "...{}..." or
 # f"...{}...".
 
 print("\\n")  # \n
@@ -26,4 +24,4 @@ print(word[-2])  # o
 print(word[-6])  # P
 
 s = "supercalifragilisticexpialidocious"
-len(s)  # 34
+print(len(s))  # 34


### PR DESCRIPTION
- Fix first line comment parsing issue
- Move `Unescape` operation from `HeapObject` to `StringContent` factory method, because we should only do unescape for constant strings read from source code.
- Refactoring some unit test cases for easy debugging.