### PR TITLE
Implement boolean and comparison expressions

### DIFF
--- a/csharp/src/SeedLang/Ast/Executor.cs
+++ b/csharp/src/SeedLang/Ast/Executor.cs
@@ -141,16 +141,16 @@ namespace SeedLang.Ast {
         Value left = i > 0 ? values[i - 1] : first;
         switch (comparison.Ops[i]) {
           case ComparisonOperator.Less:
-            currentResult = left.AsNumber() < values[i].AsNumber();
+            currentResult = ValueHelper.Less(left, values[i]);
             break;
           case ComparisonOperator.Greater:
-            currentResult = left.AsNumber() > values[i].AsNumber();
+            currentResult = ValueHelper.Greater(left, values[i]);
             break;
           case ComparisonOperator.LessEqual:
-            currentResult = left.AsNumber() <= values[i].AsNumber();
+            currentResult = ValueHelper.LessEqual(left, values[i]);
             break;
           case ComparisonOperator.GreaterEqual:
-            currentResult = left.AsNumber() >= values[i].AsNumber();
+            currentResult = ValueHelper.GreaterEqual(left, values[i]);
             break;
           case ComparisonOperator.EqEqual:
             currentResult = left.Equals(values[i]);

--- a/csharp/src/SeedLang/Interpreter/Compiler.cs
+++ b/csharp/src/SeedLang/Interpreter/Compiler.cs
@@ -27,8 +27,8 @@ namespace SeedLang.Interpreter {
     private NestedJumpStack _nestedJumpStack;
 
     // The register allocated for the result of sub-expressions. The getter resets the storage to
-    // null after getting the value to make sure the result register is set before visiting
-    // sub-expressions.
+    // null after getting the value to make sure the result register is set before visiting each
+    // sub-expression.
     private uint _registerForSubExpr {
       get {
         Debug.Assert(_registerForSubExprStorage.HasValue,
@@ -352,10 +352,9 @@ namespace SeedLang.Interpreter {
     }
 
     private void VisitBooleanOrComparisonExpression(System.Action action, Range range) {
-      // Generates LOADBOOL opcodes if the boolean or comparison expression is a sub-expression of
-      // other expressions. _registerForSubExprStorage is not null if the boolean or comparison
-      // expression is a sub-expression of other expressions, otherwise it is part of the test
-      // condition of if or while statements.
+      // Generates LOADBOOL opcodes if _registerForSubExprStorage is not null, which means the
+      // boolean or comparison expression is a sub-expression of other expressions, otherwise it is
+      // part of the test condition of if or while statements.
       uint? register = null;
       if (!(_registerForSubExprStorage is null)) {
         register = _registerForSubExpr;

--- a/csharp/src/SeedLang/Interpreter/NestedJumpStack.cs
+++ b/csharp/src/SeedLang/Interpreter/NestedJumpStack.cs
@@ -1,4 +1,3 @@
-using System.Reflection.PortableExecutable;
 // Copyright 2021-2022 The SeedV Lab.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +38,7 @@ namespace SeedLang.Interpreter {
 
     // Pops a frame when a "if" or "while" statement is finished visiting.
     internal void PopFrame() {
-      Debug.Assert(_frames.Count > 0, "Frames shall be pushed before.");
+      Debug.Assert(_frames.Count > 0, "Frames shall be pushed into the stack before.");
       Debug.Assert(_frames.Peek().TrueJumps.Count == 0, "True jumps shall be patched.");
       Debug.Assert(_frames.Peek().FalseJumps.Count == 0, "True jumps shall be patched.");
       _frames.Pop();

--- a/csharp/src/SeedLang/Interpreter/NestedJumpStack.cs
+++ b/csharp/src/SeedLang/Interpreter/NestedJumpStack.cs
@@ -1,3 +1,4 @@
+using System.Reflection.PortableExecutable;
 // Copyright 2021-2022 The SeedV Lab.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,8 +39,9 @@ namespace SeedLang.Interpreter {
 
     // Pops a frame when a "if" or "while" statement is finished visiting.
     internal void PopFrame() {
-      Debug.Assert(_frames.Count > 0 && _frames.Peek().TrueJumps.Count == 0 &&
-                   _frames.Peek().FalseJumps.Count == 0);
+      Debug.Assert(_frames.Count > 0, "Frames shall be pushed before.");
+      Debug.Assert(_frames.Peek().TrueJumps.Count == 0, "True jumps shall be patched.");
+      Debug.Assert(_frames.Peek().FalseJumps.Count == 0, "True jumps shall be patched.");
       _frames.Pop();
     }
   }

--- a/csharp/src/SeedLang/Interpreter/VM.cs
+++ b/csharp/src/SeedLang/Interpreter/VM.cs
@@ -59,7 +59,10 @@ namespace SeedLang.Interpreter {
               }
               break;
             case Opcode.LOADBOOL:
-              // TODO: implement the LOADBOOL opcode.
+              _stack[baseRegister + instr.A] = new Value(instr.B == 1);
+              if (instr.C == 1) {
+                pc++;
+              }
               break;
             case Opcode.LOADK:
               _stack[baseRegister + instr.A] = chunk.ValueOfConstId(instr.Bx);

--- a/csharp/src/SeedLang/Interpreter/VM.cs
+++ b/csharp/src/SeedLang/Interpreter/VM.cs
@@ -116,22 +116,28 @@ namespace SeedLang.Interpreter {
             case Opcode.JMP:
               pc += instr.SBx;
               break;
-            case Opcode.EQ:
-              if (ValueOfRK(chunk, instr.B, baseRegister).AsNumber() ==
-                  ValueOfRK(chunk, instr.C, baseRegister).AsNumber() == (instr.A == 1)) {
-                pc++;
+            case Opcode.EQ: {
+                bool result = ValueOfRK(chunk, instr.B, baseRegister).Equals(
+                    ValueOfRK(chunk, instr.C, baseRegister));
+                if (result == (instr.A == 1)) {
+                  pc++;
+                }
               }
               break;
-            case Opcode.LT:
-              if ((ValueOfRK(chunk, instr.B, baseRegister).AsNumber() <
-                   ValueOfRK(chunk, instr.C, baseRegister).AsNumber()) == (instr.A == 1)) {
-                pc++;
+            case Opcode.LT: {
+                bool result = ValueHelper.Less(ValueOfRK(chunk, instr.B, baseRegister),
+                                               ValueOfRK(chunk, instr.C, baseRegister));
+                if (result == (instr.A == 1)) {
+                  pc++;
+                }
               }
               break;
-            case Opcode.LE:
-              if ((ValueOfRK(chunk, instr.B, baseRegister).AsNumber() <=
-                   ValueOfRK(chunk, instr.C, baseRegister).AsNumber()) == (instr.A == 1)) {
-                pc++;
+            case Opcode.LE: {
+                bool result = ValueHelper.LessEqual(ValueOfRK(chunk, instr.B, baseRegister),
+                                                    ValueOfRK(chunk, instr.C, baseRegister));
+                if (result == (instr.A == 1)) {
+                  pc++;
+                }
               }
               break;
             case Opcode.TEST:

--- a/csharp/src/SeedLang/Runtime/ValueHelper.cs
+++ b/csharp/src/SeedLang/Runtime/ValueHelper.cs
@@ -158,6 +158,42 @@ namespace SeedLang.Runtime {
       }
     }
 
+    internal static bool Less(in Value lhs, in Value rhs) {
+      if ((lhs.IsBoolean || lhs.IsNumber) && (rhs.IsBoolean || rhs.IsNumber)) {
+        return lhs.AsNumber() < rhs.AsNumber();
+      } else {
+        throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Error, "", null,
+                                      Message.RuntimeErrorUnsupportedOperads);
+      }
+    }
+
+    internal static bool Greater(in Value lhs, in Value rhs) {
+      if ((lhs.IsBoolean || lhs.IsNumber) && (rhs.IsBoolean || rhs.IsNumber)) {
+        return lhs.AsNumber() > rhs.AsNumber();
+      } else {
+        throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Error, "", null,
+                                      Message.RuntimeErrorUnsupportedOperads);
+      }
+    }
+
+    internal static bool LessEqual(in Value lhs, in Value rhs) {
+      if ((lhs.IsBoolean || lhs.IsNumber) && (rhs.IsBoolean || rhs.IsNumber)) {
+        return lhs.AsNumber() <= rhs.AsNumber();
+      } else {
+        throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Error, "", null,
+                                      Message.RuntimeErrorUnsupportedOperads);
+      }
+    }
+
+    internal static bool GreaterEqual(in Value lhs, in Value rhs) {
+      if ((lhs.IsBoolean || lhs.IsNumber) && (rhs.IsBoolean || rhs.IsNumber)) {
+        return lhs.AsNumber() >= rhs.AsNumber();
+      } else {
+        throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Error, "", null,
+                                      Message.RuntimeErrorUnsupportedOperads);
+      }
+    }
+
     internal static double BooleanToNumber(bool value) {
       return value ? 1 : 0;
     }

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
@@ -56,6 +56,92 @@ namespace SeedLang.Interpreter.Tests {
     }
 
     [Fact]
+    public void TestCompileComparison() {
+      var expr = AstHelper.ExpressionStmt(
+        AstHelper.Comparison(AstHelper.NumberConstant(1),
+                             AstHelper.CompOps(ComparisonOperator.Less),
+                             AstHelper.NumberConstant(2))
+      );
+      var compiler = new Compiler();
+      var func = compiler.Compile(expr, _env, RunMode.Interactive);
+      string expected = (
+          $"Function <main>\n" +
+          $"  1    GETGLOB   0 0                                  {_range}\n" +
+          $"  2    LT        1 -1 -2          ; 1 2               {_range}\n" +
+          $"  3    JMP       0 1              ; to 5              {_range}\n" +
+          $"  4    LOADBOOL  1 1 1                                {_range}\n" +
+          $"  5    LOADBOOL  1 0 0                                {_range}\n" +
+          $"  6    CALL      0 1 0                                {_range}\n" +
+          $"  7    RETURN    0 0                                  \n"
+      ).Replace("\n", Environment.NewLine);
+      Assert.Equal(expected, new Disassembler(func).ToString());
+    }
+
+    [Fact]
+    public void TestCompileNilComparison() {
+      var expr = AstHelper.ExpressionStmt(
+        AstHelper.Comparison(AstHelper.NilConstant(),
+                             AstHelper.CompOps(ComparisonOperator.Less),
+                             AstHelper.NilConstant())
+      );
+      var compiler = new Compiler();
+      var func = compiler.Compile(expr, _env, RunMode.Interactive);
+      string expected = (
+          $"Function <main>\n" +
+          $"  1    GETGLOB   0 0                                  {_range}\n" +
+          $"  2    LOADNIL   2 1 0                                {_range}\n" +
+          $"  3    LOADNIL   3 1 0                                {_range}\n" +
+          $"  4    LT        1 2 3                                {_range}\n" +
+          $"  5    JMP       0 1              ; to 7              {_range}\n" +
+          $"  6    LOADBOOL  1 1 1                                {_range}\n" +
+          $"  7    LOADBOOL  1 0 0                                {_range}\n" +
+          $"  8    CALL      0 1 0                                {_range}\n" +
+          $"  9    RETURN    0 0                                  \n"
+      ).Replace("\n", Environment.NewLine);
+      Assert.Equal(expected, new Disassembler(func).ToString());
+    }
+
+    [Fact]
+    public void TestCompileBoolean() {
+      var @if = AstHelper.ExpressionStmt(
+        AstHelper.Boolean(
+          BooleanOperator.Or,
+          AstHelper.Comparison(
+            AstHelper.NumberConstant(1),
+            AstHelper.CompOps(ComparisonOperator.Less, ComparisonOperator.Less),
+            AstHelper.NumberConstant(2),
+            AstHelper.NumberConstant(3)
+          ),
+          AstHelper.Comparison(
+            AstHelper.NumberConstant(1),
+            AstHelper.CompOps(ComparisonOperator.LessEqual, ComparisonOperator.LessEqual),
+            AstHelper.NumberConstant(2),
+            AstHelper.NumberConstant(3)
+          )
+        )
+      );
+      var compiler = new Compiler();
+      var func = compiler.Compile(@if, _env, RunMode.Interactive);
+      string expected = (
+          $"Function <main>\n" +
+          $"  1    GETGLOB   0 0                                  {_range}\n" +
+          $"  2    LT        1 -1 -2          ; 1 2               {_range}\n" +
+          $"  3    JMP       0 2              ; to 6              {_range}\n" +
+          $"  4    LT        0 -2 -3          ; 2 3               {_range}\n" +
+          $"  5    JMP       0 4              ; to 10             {_range}\n" +
+          $"  6    LE        1 -1 -2          ; 1 2               {_range}\n" +
+          $"  7    JMP       0 3              ; to 11             {_range}\n" +
+          $"  8    LE        1 -2 -3          ; 2 3               {_range}\n" +
+          $"  9    JMP       0 1              ; to 11             {_range}\n" +
+          $"  10   LOADBOOL  1 1 1                                {_range}\n" +
+          $"  11   LOADBOOL  1 0 0                                {_range}\n" +
+          $"  12   CALL      0 1 0                                {_range}\n" +
+          $"  13   RETURN    0 0                                  \n"
+      ).Replace("\n", Environment.NewLine);
+      Assert.Equal(expected, new Disassembler(func).ToString());
+    }
+
+    [Fact]
     public void TestCompileBinary() {
       var expr = AstHelper.ExpressionStmt(AstHelper.Binary(AstHelper.NumberConstant(1),
                                                            BinaryOperator.Add,

--- a/csharp/tests/SeedLang.Tests/Runtime/ExecutorPythonTests.cs
+++ b/csharp/tests/SeedLang.Tests/Runtime/ExecutorPythonTests.cs
@@ -35,6 +35,12 @@ namespace SeedLang.Runtime.Tests {
 2 * [1, 2, 3]
 (1, 2, 3) * 3
 -1 * (1, 2, 3)
+1 < 2 < 3
+1 < 2 == 3
+1 < 2 < 3 and 1 < 2 == 3
+1 < 2 < 3 or 1 < 2 == 3
+None == None
+None != None
 ";
       string result = @"3
 1
@@ -51,6 +57,12 @@ namespace SeedLang.Runtime.Tests {
 [1, 2, 3, 1, 2, 3]
 (1, 2, 3, 1, 2, 3, 1, 2, 3)
 ()
+True
+False
+False
+True
+True
+False
 ";
       TestExecutor(source, result);
     }


### PR DESCRIPTION
Fix #134 

Supports following code:

```python
1 < 2 < 3
1 < 2 == 3
1 < 2 < 3 and 1 < 2 == 3
1 < 2 < 3 or 1 < 2 == 3
None == None
None != None
```