### PR TITLE
Implement Dict

### DIFF
--- a/csharp/src/SeedLang/Ast/AstStringBuilder.cs
+++ b/csharp/src/SeedLang/Ast/AstStringBuilder.cs
@@ -166,6 +166,15 @@ namespace SeedLang.Ast {
       Exit();
     }
 
+    protected override void Visit(DictExpression dict) {
+      Enter(dict);
+      for (int i = 0; i < dict.Keys.Length; i++) {
+        Visit(dict.Keys[i]);
+        Visit(dict.Values[i]);
+      }
+      Exit();
+    }
+
     protected override void Visit(ListExpression list) {
       Enter(list);
       foreach (Expression expr in list.Exprs) {

--- a/csharp/src/SeedLang/Ast/AstStringBuilder.cs
+++ b/csharp/src/SeedLang/Ast/AstStringBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 // Copyright 2021-2022 The SeedV Lab.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -168,9 +169,9 @@ namespace SeedLang.Ast {
 
     protected override void Visit(DictExpression dict) {
       Enter(dict);
-      for (int i = 0; i < dict.Keys.Length; i++) {
-        Visit(dict.Keys[i]);
-        Visit(dict.Values[i]);
+      foreach (var item in dict.Items) {
+        Visit(item.Key);
+        Visit(item.Value);
       }
       Exit();
     }

--- a/csharp/src/SeedLang/Ast/AstWalker.cs
+++ b/csharp/src/SeedLang/Ast/AstWalker.cs
@@ -61,6 +61,9 @@ namespace SeedLang.Ast {
         case StringConstantExpression stringConstant:
           Visit(stringConstant);
           break;
+        case DictExpression dict:
+          Visit(dict);
+          break;
         case ListExpression list:
           Visit(list);
           break;
@@ -124,6 +127,7 @@ namespace SeedLang.Ast {
     protected abstract void Visit(NilConstantExpression nilConstant);
     protected abstract void Visit(NumberConstantExpression numberConstant);
     protected abstract void Visit(StringConstantExpression stringConstant);
+    protected abstract void Visit(DictExpression tuple);
     protected abstract void Visit(ListExpression list);
     protected abstract void Visit(TupleExpression tuple);
     protected abstract void Visit(SubscriptExpression subscript);

--- a/csharp/src/SeedLang/Ast/Executor.cs
+++ b/csharp/src/SeedLang/Ast/Executor.cs
@@ -219,10 +219,10 @@ namespace SeedLang.Ast {
 
     protected override void Visit(DictExpression dict) {
       var initialValues = new Dictionary<Value, Value>();
-      for (int i = 0; i < dict.Keys.Length; i++) {
-        Visit(dict.Keys[i]);
+      foreach (var item in dict.Items) {
+        Visit(item.Key);
         Value key = _expressionResult;
-        Visit(dict.Values[i]);
+        Visit(item.Value);
         initialValues[key] = _expressionResult;
       }
       _expressionResult = new Value(initialValues);

--- a/csharp/src/SeedLang/Ast/Executor.cs
+++ b/csharp/src/SeedLang/Ast/Executor.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using SeedLang.Common;
 using SeedLang.Runtime;
@@ -237,12 +238,12 @@ namespace SeedLang.Ast {
     }
 
     protected override void Visit(TupleExpression list) {
-      var initialValues = new Value[list.Exprs.Length];
+      var builder = ImmutableArray.CreateBuilder<Value>(list.Exprs.Length);
       for (int i = 0; i < list.Exprs.Length; i++) {
         Visit(list.Exprs[i]);
-        initialValues[i] = _expressionResult;
+        builder.Add(_expressionResult);
       }
-      _expressionResult = new Value(initialValues);
+      _expressionResult = new Value(builder.MoveToImmutable());
     }
 
     protected override void Visit(SubscriptExpression subscript) {
@@ -361,11 +362,12 @@ namespace SeedLang.Ast {
     }
 
     private void Pack(Expression[] targets, Expression[] exprs, Range range) {
-      var values = new Value[exprs.Length];
+      var builder = ImmutableArray.CreateBuilder<Value>(exprs.Length);
       for (int i = 0; i < exprs.Length; i++) {
         Visit(exprs[i]);
-        values[i] = _expressionResult;
+        builder.Add(_expressionResult);
       }
+      ImmutableArray<Value> values = builder.MoveToImmutable();
       if (targets.Length == 1) {
         Assign(targets[0], new Value(values), range);
       } else if (targets.Length == values.Length) {

--- a/csharp/src/SeedLang/Ast/Expressions.cs
+++ b/csharp/src/SeedLang/Ast/Expressions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 // Copyright 2021-2022 The SeedV Lab.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,9 +69,8 @@ namespace SeedLang.Ast {
     }
 
     // The factory method to create a dictionary expression.
-    internal static DictExpression Dict(Expression[] keys, Expression[] values, Range range) {
-      Debug.Assert(keys.Length == values.Length);
-      return new DictExpression(keys, values, range);
+    internal static DictExpression Dict(KeyValuePair<Expression, Expression>[] items, Range range) {
+      return new DictExpression(items, range);
     }
 
     // The factory method to create a list expression.
@@ -188,12 +188,11 @@ namespace SeedLang.Ast {
   }
 
   internal class DictExpression : Expression {
-    public Expression[] Keys { get; }
-    public Expression[] Values { get; }
+    public KeyValuePair<Expression, Expression>[] Items { get; }
 
-    internal DictExpression(Expression[] keys, Expression[] values, Range range) : base(range) {
-      Keys = keys;
-      Values = values;
+    internal DictExpression(KeyValuePair<Expression, Expression>[] items, Range range) :
+        base(range) {
+      Items = items;
     }
   }
 

--- a/csharp/src/SeedLang/Ast/Expressions.cs
+++ b/csharp/src/SeedLang/Ast/Expressions.cs
@@ -67,6 +67,12 @@ namespace SeedLang.Ast {
       return new StringConstantExpression(ValueHelper.Unescape(value), range);
     }
 
+    // The factory method to create a dictionary expression.
+    internal static DictExpression Dict(Expression[] keys, Expression[] values, Range range) {
+      Debug.Assert(keys.Length == values.Length);
+      return new DictExpression(keys, values, range);
+    }
+
     // The factory method to create a list expression.
     internal static ListExpression List(Expression[] exprs, Range range) {
       return new ListExpression(exprs, range);
@@ -178,6 +184,16 @@ namespace SeedLang.Ast {
 
     internal StringConstantExpression(string value, Range range) : base(range) {
       Value = value;
+    }
+  }
+
+  internal class DictExpression : Expression {
+    public Expression[] Keys { get; }
+    public Expression[] Values { get; }
+
+    internal DictExpression(Expression[] keys, Expression[] values, Range range) : base(range) {
+      Keys = keys;
+      Values = values;
     }
   }
 

--- a/csharp/src/SeedLang/Common/Message.cs
+++ b/csharp/src/SeedLang/Common/Message.cs
@@ -74,10 +74,12 @@ namespace SeedLang.Common {
     RuntimeErrorIncorrectArgsCount,     // Incorrect arguments count runtime error.
     RuntimeErrorIncorrectUnpackCount,   // Incorrect number of values to be unpack runtime error.
     RuntimeErrorInvalidIndex,           // Not a valid integer index runtime error.
+    RuntimeErrorNoKey,                  // There is no key in the dictionary.
     RuntimeErrorNotCallable,            // Value type not callable runtime error.
     RuntimeErrorNotCountable,           // Value type not countable runtime error.
     RuntimeErrorNotSubscriptable,       // Value type not subscriptable runtime error.
     RuntimeErrorNotSupportAssignment,   // The value type does not support assignment.
+    RuntimeErrorUnhashableType,         // The type of keys is unhashable.
     RuntimeErrorUnsupportedOperads,     // The type of operads is not supported by the operator.
     RuntimeErrorOutOfRange,             // Index out of range runtime error.
     RuntimeErrorOverflow,               // Overflow runtime error.

--- a/csharp/src/SeedLang/Common/Message.cs
+++ b/csharp/src/SeedLang/Common/Message.cs
@@ -74,7 +74,7 @@ namespace SeedLang.Common {
     RuntimeErrorIncorrectArgsCount,     // Incorrect arguments count runtime error.
     RuntimeErrorIncorrectUnpackCount,   // Incorrect number of values to be unpack runtime error.
     RuntimeErrorInvalidIndex,           // Not a valid integer index runtime error.
-    RuntimeErrorNoKey,                  // There is no key in the dictionary.
+    RuntimeErrorNoKey,                  // Couldn't find the given key in the dictionary.
     RuntimeErrorNotCallable,            // Value type not callable runtime error.
     RuntimeErrorNotCountable,           // Value type not countable runtime error.
     RuntimeErrorNotSubscriptable,       // Value type not subscriptable runtime error.

--- a/csharp/src/SeedLang/Interpreter/Compiler.cs
+++ b/csharp/src/SeedLang/Interpreter/Compiler.cs
@@ -157,17 +157,17 @@ namespace SeedLang.Interpreter {
       _variableResolver.BeginExpressionScope();
       uint target = _registerForSubExpr;
       uint? first = null;
-      for (int i = 0; i < dict.Keys.Length; i++) {
+      foreach (var item in dict.Items) {
         uint register = _variableResolver.AllocateRegister();
         if (!first.HasValue) {
           first = register;
         }
         _registerForSubExpr = register;
-        Visit(dict.Keys[i]);
+        Visit(item.Key);
         _registerForSubExpr = _variableResolver.AllocateRegister();
-        Visit(dict.Values[i]);
+        Visit(item.Value);
       }
-      _chunk.Emit(Opcode.NEWDICT, target, first ?? 0, (uint)dict.Keys.Length * 2, dict.Range);
+      _chunk.Emit(Opcode.NEWDICT, target, first ?? 0, (uint)dict.Items.Length * 2, dict.Range);
       _variableResolver.EndExpressionScope();
     }
 

--- a/csharp/src/SeedLang/Interpreter/Opcode.cs
+++ b/csharp/src/SeedLang/Interpreter/Opcode.cs
@@ -25,6 +25,8 @@ namespace SeedLang.Interpreter {
     SETGLOB,      // Gbl[Kst(Bx)] := R[A]
     NEWTUPLE,     // R(A) := (R(B), R(B+1), ..., R(B+C-1)), C is the count of initial elements
     NEWLIST,      // R(A) := [R(B), R(B+1), ..., R(B+C-1)], C is the count of initial elements
+    NEWDICT,      // R(A) := {R(B): R(B+1), ..., R(B+C-2): R(B+C-1)], C is the count of initial keys
+                  // and values
     GETELEM,      // R(A) := R(B)[RK(C)]
     SETELEM,      // R(A)[RK(B)] := RK(C)
     ADD,          // R(A) := RK(B) + RK(C)
@@ -65,6 +67,7 @@ namespace SeedLang.Interpreter {
         case Opcode.LOADBOOL:
         case Opcode.NEWTUPLE:
         case Opcode.NEWLIST:
+        case Opcode.NEWDICT:
         case Opcode.GETELEM:
         case Opcode.SETELEM:
         case Opcode.ADD:

--- a/csharp/src/SeedLang/Interpreter/VM.cs
+++ b/csharp/src/SeedLang/Interpreter/VM.cs
@@ -81,6 +81,17 @@ namespace SeedLang.Interpreter {
               }
               _stack[baseRegister + instr.A] = new Value(list);
               break;
+            case Opcode.NEWDICT:
+              int count = (int)instr.C / 2;
+              var dict = new Dictionary<Value, Value>(count);
+              uint dictRegister = baseRegister + instr.A;
+              uint kvStart = baseRegister + instr.B;
+              for (uint i = 0; i < count; i++) {
+                uint keyRegister = kvStart + i * 2;
+                dict[_stack[keyRegister]] = _stack[keyRegister + 1];
+              }
+              _stack[dictRegister] = new Value(dict);
+              break;
             case Opcode.GETGLOB:
               _stack[baseRegister + instr.A] = Env.GetVariable(instr.Bx);
               break;
@@ -194,12 +205,12 @@ namespace SeedLang.Interpreter {
     }
 
     private void GetElement(Chunk chunk, Instruction instr, uint baseRegister) {
-      double index = ValueOfRK(chunk, instr.C, baseRegister).AsNumber();
+      Value index = ValueOfRK(chunk, instr.C, baseRegister);
       _stack[baseRegister + instr.A] = _stack[baseRegister + instr.B][index];
     }
 
     private void SetElement(Chunk chunk, Instruction instr, uint baseRegister) {
-      double index = ValueOfRK(chunk, instr.B, baseRegister).AsNumber();
+      Value index = ValueOfRK(chunk, instr.B, baseRegister);
       _stack[baseRegister + instr.A][index] = ValueOfRK(chunk, instr.C, baseRegister);
     }
 

--- a/csharp/src/SeedLang/Interpreter/VM.cs
+++ b/csharp/src/SeedLang/Interpreter/VM.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using SeedLang.Common;
 using SeedLang.Runtime;
@@ -68,11 +69,11 @@ namespace SeedLang.Interpreter {
               _stack[baseRegister + instr.A] = chunk.ValueOfConstId(instr.Bx);
               break;
             case Opcode.NEWTUPLE:
-              var tuple = new Value[instr.C];
+              var builder = ImmutableArray.CreateBuilder<Value>((int)instr.C);
               for (int i = 0; i < instr.C; i++) {
-                tuple[i] = _stack[baseRegister + instr.B + i];
+                builder.Add(_stack[baseRegister + instr.B + i]);
               }
-              _stack[baseRegister + instr.A] = new Value(tuple);
+              _stack[baseRegister + instr.A] = new Value(builder.MoveToImmutable());
               break;
             case Opcode.NEWLIST:
               var list = new List<Value>((int)instr.C);

--- a/csharp/src/SeedLang/Runtime/HeapObject.cs
+++ b/csharp/src/SeedLang/Runtime/HeapObject.cs
@@ -60,6 +60,15 @@ namespace SeedLang.Runtime {
     private readonly object _object;
 
     public HeapObject(object obj) {
+      switch (obj) {
+        case Dict dict:
+          foreach (var item in dict) {
+            CheckKey(item.Key);
+          }
+          break;
+        default:
+          break;
+      }
       _object = obj;
       Debug.Assert(IsString || IsList || IsFunction || IsRange || IsTuple || IsDict,
                    $"Unsupported object type: {_object.GetType()}");
@@ -281,12 +290,7 @@ namespace SeedLang.Runtime {
     private static string TupleToString(ImmutableArray<Value> tuple) {
       var sb = new StringBuilder();
       sb.Append('(');
-      for (int i = 0; i < tuple.Length; i++) {
-        sb.Append(tuple[i]);
-        if (i < tuple.Length - 1) {
-          sb.Append(", ");
-        }
-      }
+      sb.Append(string.Join(", ", tuple));
       sb.Append(')');
       return sb.ToString();
     }
@@ -298,15 +302,7 @@ namespace SeedLang.Runtime {
         sb.Append("...");
       } else {
         _visitedObjects.Add(this);
-        bool first = true;
-        foreach (Value value in list) {
-          if (first) {
-            first = false;
-          } else {
-            sb.Append(", ");
-          }
-          sb.Append(value);
-        }
+        sb.Append(string.Join(", ", list));
         _visitedObjects.Remove(this);
       }
       sb.Append(']');

--- a/csharp/src/SeedLang/Runtime/HeapObject.cs
+++ b/csharp/src/SeedLang/Runtime/HeapObject.cs
@@ -21,6 +21,7 @@ using SeedLang.Common;
 namespace SeedLang.Runtime {
   using List = List<Value>;
   using Tuple = IReadOnlyList<Value>;
+  using Dict = Dictionary<Value, Value>;
 
   // A class to hold heap allocated objects.
   internal partial class HeapObject : IEquatable<HeapObject> {
@@ -29,6 +30,7 @@ namespace SeedLang.Runtime {
     public bool IsFunction => _object is IFunction;
     public bool IsRange => _object is Range;
     public bool IsTuple => _object is Tuple;
+    public bool IsDict => _object is Dict;
 
     public int Length {
       get {
@@ -41,6 +43,8 @@ namespace SeedLang.Runtime {
             return range.Length;
           case Tuple tuple:
             return tuple.Count;
+          case Dict dict:
+            return dict.Count;
           default:
             throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Fatal, "", null,
                                           Message.RuntimeErrorNotCountable);
@@ -54,7 +58,7 @@ namespace SeedLang.Runtime {
 
     public HeapObject(object obj) {
       _object = obj;
-      Debug.Assert(IsString || IsList || IsFunction || IsRange || IsTuple,
+      Debug.Assert(IsString || IsList || IsFunction || IsRange || IsTuple || IsDict,
                    $"Unsupported object type: {_object.GetType()}");
     }
 
@@ -99,7 +103,7 @@ namespace SeedLang.Runtime {
     }
 
     public override string ToString() {
-      return AsString();
+      return IsString ? $"'{AsString()}'" : AsString();
     }
 
     internal bool AsBoolean() {
@@ -112,6 +116,8 @@ namespace SeedLang.Runtime {
           return range.Length != 0;
         case Tuple tuple:
           return tuple.Count != 0;
+        case Dict dict:
+          return dict.Count != 0;
         default:
           throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Fatal, "", null,
                                         Message.RuntimeErrorInvalidCast);
@@ -140,6 +146,8 @@ namespace SeedLang.Runtime {
           return range.ToString();
         case Tuple tuple:
           return TupleToString(tuple);
+        case Dict dict:
+          return DictToString(dict);
         default:
           throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Fatal, "", null,
                                         Message.RuntimeErrorInvalidCast);
@@ -176,17 +184,34 @@ namespace SeedLang.Runtime {
       }
     }
 
-    internal Value this[double index] {
+    internal Dict AsDict() {
+      switch (_object) {
+        case Dict dict:
+          return dict;
+        default:
+          throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Fatal, "", null,
+                                        Message.RuntimeErrorInvalidCast);
+      }
+    }
+
+    internal Value this[Value key] {
       get {
         switch (_object) {
           case string str:
-            return new Value(str[ToIntIndex(index, str.Length)].ToString());
+            return new Value(str[ToIntIndex(key.AsNumber(), str.Length)].ToString());
           case List list:
-            return list[ToIntIndex(index, list.Count)];
+            return list[ToIntIndex(key.AsNumber(), list.Count)];
           case Range range:
-            return range[ToIntIndex(index, range.Length)];
+            return range[ToIntIndex(key.AsNumber(), range.Length)];
           case Tuple tuple:
-            return tuple[ToIntIndex(index, tuple.Count)];
+            return tuple[ToIntIndex(key.AsNumber(), tuple.Count)];
+          case Dict dict:
+            CheckKey(key);
+            if (dict.ContainsKey(key)) {
+              return dict[key];
+            }
+            throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Fatal, "", null,
+                                          Message.RuntimeErrorNoKey);
           default:
             throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Fatal, "", null,
                                           Message.RuntimeErrorNotSubscriptable);
@@ -197,7 +222,11 @@ namespace SeedLang.Runtime {
           case string _:
             throw new NotImplementedException();
           case List list:
-            list[ToIntIndex(index, list.Count)] = value;
+            list[ToIntIndex(key.AsNumber(), list.Count)] = value;
+            break;
+          case Dict dict:
+            CheckKey(key);
+            dict[key] = value;
             break;
           case Range _:
           case Tuple _:
@@ -220,6 +249,14 @@ namespace SeedLang.Runtime {
                                       Message.RuntimeErrorOutOfRange);
       }
       return intIndex < 0 ? length + intIndex : intIndex;
+    }
+
+    private static void CheckKey(Value key) {
+      if (!key.IsNil && !key.IsBoolean && !key.IsNumber && !key.IsString && !key.IsRange &&
+          !key.IsTuple) {
+        throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Fatal, "", null,
+                                      Message.RuntimeErrorInvalidIndex);
+      }
     }
 
     private static string TupleToString(IReadOnlyList<Value> tuple) {
@@ -254,6 +291,30 @@ namespace SeedLang.Runtime {
         _visitedObjects.Remove(this);
       }
       sb.Append(']');
+      return sb.ToString();
+    }
+
+    private string DictToString(IReadOnlyDictionary<Value, Value> dict) {
+      var sb = new StringBuilder();
+      sb.Append('{');
+      if (_visitedObjects.Contains(this)) {
+        sb.Append("...");
+      } else {
+        _visitedObjects.Add(this);
+        bool first = true;
+        foreach (var item in dict) {
+          if (first) {
+            first = false;
+          } else {
+            sb.Append(", ");
+          }
+          sb.Append(item.Key);
+          sb.Append(": ");
+          sb.Append(item.Value);
+        }
+        _visitedObjects.Remove(this);
+      }
+      sb.Append('}');
       return sb.ToString();
     }
   }

--- a/csharp/src/SeedLang/Runtime/IValue.cs
+++ b/csharp/src/SeedLang/Runtime/IValue.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 namespace SeedLang.Runtime {
+  // TODO: check if subscription of IValue is needed? And how to implement it?
   public interface IValue {
     bool IsNil { get; }
     bool IsBoolean { get; }

--- a/csharp/src/SeedLang/Runtime/IValue.cs
+++ b/csharp/src/SeedLang/Runtime/IValue.cs
@@ -25,6 +25,5 @@ namespace SeedLang.Runtime {
     double Number { get; }
     string String { get; }
     int Length { get; }
-    IValue this[int index] { get; }
   }
 }

--- a/csharp/src/SeedLang/Runtime/NativeFunctions.cs
+++ b/csharp/src/SeedLang/Runtime/NativeFunctions.cs
@@ -44,11 +44,7 @@ namespace SeedLang.Runtime {
                                       Message.RuntimeErrorIncorrectArgsCount);
       }
       if (!args[offset].IsNil) {
-        if (args[offset].IsString) {
-          sys.Stdout.WriteLine($"'{args[offset].AsString()}'");
-        } else {
-          sys.Stdout.WriteLine(args[offset].AsString());
-        }
+        sys.Stdout.WriteLine(args[offset]);
       }
       return new Value();
     }
@@ -91,15 +87,19 @@ namespace SeedLang.Runtime {
       }
       var list = new List<Value>();
       for (int i = 0; i < args[offset].Length; i++) {
-        list.Add(args[offset][i]);
+        list.Add(args[offset][new Value(i)]);
       }
       return new Value(list);
     }
 
     private static Value PrintFunc(Value[] args, int offset, int length, Sys sys) {
       for (int i = 0; i < length; i++) {
-        sys.Stdout.WriteLine(args[offset + i].AsString());
+        if (i > 0) {
+          sys.Stdout.Write(" ");
+        }
+        sys.Stdout.Write(args[offset + i].AsString());
       }
+      sys.Stdout.WriteLine();
       return new Value();
     }
 

--- a/csharp/src/SeedLang/Runtime/Value.cs
+++ b/csharp/src/SeedLang/Runtime/Value.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using SeedLang.Common;
 
 namespace SeedLang.Runtime {
@@ -212,9 +213,18 @@ namespace SeedLang.Runtime {
       }
     }
 
-    internal IReadOnlyList<Value> AsTuple() {
+    internal ImmutableArray<Value> AsTuple() {
       if (_type == ValueType.Object) {
         return _object.AsTuple();
+      } else {
+        throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Fatal, "", null,
+                                      Message.RuntimeErrorInvalidCast);
+      }
+    }
+
+    internal Dictionary<Value, Value> AsDict() {
+      if (_type == ValueType.Object) {
+        return _object.AsDict();
       } else {
         throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Fatal, "", null,
                                       Message.RuntimeErrorInvalidCast);

--- a/csharp/src/SeedLang/Runtime/Value.cs
+++ b/csharp/src/SeedLang/Runtime/Value.cs
@@ -40,6 +40,7 @@ namespace SeedLang.Runtime {
     public bool IsFunction => _type == ValueType.Object && _object.IsFunction;
     public bool IsRange => _type == ValueType.Object && _object.IsRange;
     public bool IsTuple => _type == ValueType.Object && _object.IsTuple;
+    public bool IsDict => _type == ValueType.Object && _object.IsDict;
 
     public int Length {
       get {
@@ -128,10 +129,10 @@ namespace SeedLang.Runtime {
       }
     }
 
-    internal Value this[double index] {
+    internal Value this[Value key] {
       get {
         if (_type == ValueType.Object) {
-          return _object[index];
+          return _object[key];
         } else {
           throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Fatal, "", null,
                                         Message.RuntimeErrorNotSubscriptable);
@@ -139,7 +140,7 @@ namespace SeedLang.Runtime {
       }
       set {
         if (_type == ValueType.Object) {
-          _object[index] = value;
+          _object[key] = value;
         } else {
           throw new DiagnosticException(SystemReporters.SeedRuntime, Severity.Fatal, "", null,
                                         Message.RuntimeErrorNotSubscriptable);

--- a/csharp/src/SeedLang/Runtime/ValueWrapper.cs
+++ b/csharp/src/SeedLang/Runtime/ValueWrapper.cs
@@ -35,10 +35,6 @@ namespace SeedLang.Runtime {
     public double Number => _value.AsNumber();
     public string String => _value.AsString();
 
-    public IValue this[int index] {
-      get => new ValueWrapper(_value[index]);
-    }
-
     public override string ToString() {
       return _value.ToString();
     }

--- a/csharp/src/SeedLang/X/SeedPythonVisitor.cs
+++ b/csharp/src/SeedLang/X/SeedPythonVisitor.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Antlr4.Runtime;
 using Antlr4.Runtime.Misc;
 using Antlr4.Runtime.Tree;
@@ -292,6 +293,26 @@ namespace SeedLang.X {
     public override AstNode VisitGroup([NotNull] SeedPythonParser.GroupContext context) {
       return _helper.BuildGrouping(context.OPEN_PAREN().Symbol, context.expression(),
                                    context.CLOSE_PAREN().Symbol, this);
+    }
+
+    public override AstNode VisitDict([NotNull] SeedPythonParser.DictContext context) {
+      SeedPythonParser.KvpairsContext kvPairs = context.kvpairs();
+      var keyContexts = new List<ParserRuleContext>();
+      var valueContexts = new List<ParserRuleContext>();
+      var colonNodes = new List<IToken>();
+      ITerminalNode[] commaNodes = Array.Empty<ITerminalNode>();
+      if (!(kvPairs is null)) {
+        foreach (SeedPythonParser.KvpairContext kvPair in kvPairs.kvpair()) {
+          ParserRuleContext[] exprs = kvPair.expression();
+          Debug.Assert(exprs.Length == 2);
+          keyContexts.Add(exprs[0]);
+          valueContexts.Add(exprs[1]);
+          colonNodes.Add(kvPair.COLON().Symbol);
+        }
+        commaNodes = kvPairs.COMMA();
+      }
+      return _helper.BuildDict(context.OPEN_BRACE().Symbol, keyContexts, valueContexts, colonNodes,
+                               commaNodes, context.CLOSE_BRACE().Symbol, this);
     }
 
     public override AstNode VisitList([NotNull] SeedPythonParser.ListContext context) {

--- a/csharp/src/SeedLang/X/VisitorHelper.cs
+++ b/csharp/src/SeedLang/X/VisitorHelper.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 // Copyright 2021-2022 The SeedV Lab.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -225,17 +226,17 @@ namespace SeedLang.X {
                    keyContexts.Count == commaNodes.Length + 1);
       TextRange openBraceRange = CodeReferenceUtils.RangeOfToken(openBraceToken);
       AddSemanticToken(TokenType.OpenBrace, openBraceRange);
-      var keys = new Expression[keyContexts.Count];
-      var values = new Expression[valueContexts.Count];
+      var keyValues = new KeyValuePair<Expression, Expression>[keyContexts.Count];
       for (int i = 0; i < keyContexts.Count; i++) {
-        keys[i] = visitor.Visit(keyContexts[i]) as Expression;
+        var key = visitor.Visit(keyContexts[i]) as Expression;
         AddSemanticToken(TokenType.Symbol, CodeReferenceUtils.RangeOfToken(colonNodes[i]));
-        values[i] = visitor.Visit(valueContexts[i]) as Expression;
+        var value = visitor.Visit(valueContexts[i]) as Expression;
+        keyValues[i] = new KeyValuePair<Expression, Expression>(key, value);
       }
       TextRange closeBraceRange = CodeReferenceUtils.RangeOfToken(closeBraceToken);
       AddSemanticToken(TokenType.CloseBrace, closeBraceRange);
       TextRange range = CodeReferenceUtils.CombineRanges(openBraceRange, closeBraceRange);
-      return Expression.Dict(keys, values, range);
+      return Expression.Dict(keyValues, range);
     }
 
     // Builds list expressions.

--- a/csharp/tests/SeedLang.Tests/Ast/ExecutorStatementsTests.cs
+++ b/csharp/tests/SeedLang.Tests/Ast/ExecutorStatementsTests.cs
@@ -139,6 +139,20 @@ namespace SeedLang.Ast.Tests {
     }
 
     [Fact]
+    public void TestDict() {
+      var eval = AstHelper.ExpressionStmt(
+        AstHelper.Dict(AstHelper.Keys(AstHelper.StringConstant("1"), AstHelper.NumberConstant(2),
+                                      AstHelper.Tuple(AstHelper.NumberConstant(1),
+                                                      AstHelper.NumberConstant(2))),
+                       AstHelper.NumberConstant(1),
+                       AstHelper.NumberConstant(2),
+                       AstHelper.NumberConstant(3))
+      );
+      (string output, MockupVisualizer _) = Run(eval);
+      Assert.Equal("{'1': 1, 2: 2, (1, 2): 3}" + Environment.NewLine, output);
+    }
+
+    [Fact]
     public void TestList() {
       var eval = AstHelper.ExpressionStmt(
         AstHelper.List(AstHelper.NumberConstant(1),
@@ -308,7 +322,7 @@ namespace SeedLang.Ast.Tests {
       );
       (string output, MockupVisualizer visualizer) = Run(block);
       Assert.Equal($"'{testString}'" + Environment.NewLine, output);
-      var expectedOutput = $"{AstHelper.TextRange} {str} = {testString}" + Environment.NewLine;
+      var expectedOutput = $"{AstHelper.TextRange} {str} = '{testString}'" + Environment.NewLine;
       Assert.Equal(expectedOutput, visualizer.ToString());
     }
 

--- a/csharp/tests/SeedLang.Tests/Ast/ExecutorStatementsTests.cs
+++ b/csharp/tests/SeedLang.Tests/Ast/ExecutorStatementsTests.cs
@@ -141,12 +141,13 @@ namespace SeedLang.Ast.Tests {
     [Fact]
     public void TestDict() {
       var eval = AstHelper.ExpressionStmt(
-        AstHelper.Dict(AstHelper.Keys(AstHelper.StringConstant("1"), AstHelper.NumberConstant(2),
-                                      AstHelper.Tuple(AstHelper.NumberConstant(1),
-                                                      AstHelper.NumberConstant(2))),
-                       AstHelper.NumberConstant(1),
-                       AstHelper.NumberConstant(2),
-                       AstHelper.NumberConstant(3))
+        AstHelper.Dict(
+          AstHelper.KeyValue(AstHelper.StringConstant("1"), AstHelper.NumberConstant(1)),
+          AstHelper.KeyValue(AstHelper.NumberConstant(2), AstHelper.NumberConstant(2)),
+          AstHelper.KeyValue(AstHelper.Tuple(AstHelper.NumberConstant(1),
+                                             AstHelper.NumberConstant(2)),
+                             AstHelper.NumberConstant(3))
+        )
       );
       (string output, MockupVisualizer _) = Run(eval);
       Assert.Equal("{'1': 1, 2: 2, (1, 2): 3}" + Environment.NewLine, output);

--- a/csharp/tests/SeedLang.Tests/Helper/AstHelper.cs
+++ b/csharp/tests/SeedLang.Tests/Helper/AstHelper.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
+using System.Collections.Generic;
 using SeedLang.Ast;
 using SeedLang.Common;
 using SeedLang.Runtime;
@@ -82,12 +82,12 @@ namespace SeedLang.Tests.Helper {
       return Statement.If(test, thenBody, elseBody, TextRange);
     }
 
-    internal static DictExpression Dict(Expression[] keys, params Expression[] values) {
-      return Expression.Dict(keys, values, TextRange);
+    internal static DictExpression Dict(params KeyValuePair<Expression, Expression>[] items) {
+      return Expression.Dict(items, TextRange);
     }
 
-    internal static Expression[] Keys(params Expression[] keys) {
-      return keys;
+    internal static KeyValuePair<Expression, Expression> KeyValue(Expression key, Expression value) {
+      return new KeyValuePair<Expression, Expression>(key, value);
     }
 
     internal static ListExpression List(params Expression[] exprs) {

--- a/csharp/tests/SeedLang.Tests/Helper/AstHelper.cs
+++ b/csharp/tests/SeedLang.Tests/Helper/AstHelper.cs
@@ -82,12 +82,12 @@ namespace SeedLang.Tests.Helper {
       return Statement.If(test, thenBody, elseBody, TextRange);
     }
 
-    internal static Expression[] Keys(params Expression[] keys) {
-      return keys;
-    }
-
     internal static DictExpression Dict(Expression[] keys, params Expression[] values) {
       return Expression.Dict(keys, values, TextRange);
+    }
+
+    internal static Expression[] Keys(params Expression[] keys) {
+      return keys;
     }
 
     internal static ListExpression List(params Expression[] exprs) {

--- a/csharp/tests/SeedLang.Tests/Helper/AstHelper.cs
+++ b/csharp/tests/SeedLang.Tests/Helper/AstHelper.cs
@@ -82,6 +82,14 @@ namespace SeedLang.Tests.Helper {
       return Statement.If(test, thenBody, elseBody, TextRange);
     }
 
+    internal static Expression[] Keys(params Expression[] keys) {
+      return keys;
+    }
+
+    internal static DictExpression Dict(Expression[] keys, params Expression[] values) {
+      return Expression.Dict(keys, values, TextRange);
+    }
+
     internal static ListExpression List(params Expression[] exprs) {
       return Expression.List(exprs, TextRange);
     }

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
@@ -763,6 +763,42 @@ namespace SeedLang.Interpreter.Tests {
     }
 
     [Fact]
+    public void TestCompileEmptyDict() {
+      var dict = AstHelper.ExpressionStmt(AstHelper.Dict(AstHelper.Keys()));
+      var compiler = new Compiler();
+      var func = compiler.Compile(dict, _env, RunMode.Interactive);
+      string expected = (
+          $"Function <main>\n" +
+          $"  1    GETGLOB   0 {_printValFunc}                                  {_range}\n" +
+          $"  2    NEWDICT   1 0 0                                {_range}\n" +
+          $"  3    CALL      0 1 0                                {_range}\n" +
+          $"  4    RETURN    0 0                                  \n"
+      ).Replace("\n", Environment.NewLine);
+      Assert.Equal(expected, new Disassembler(func).ToString());
+    }
+
+    [Fact]
+    public void TestCompileDict() {
+      var dict = AstHelper.ExpressionStmt(
+        AstHelper.Dict(AstHelper.Keys(AstHelper.NumberConstant(1), AstHelper.NumberConstant(2)),
+                       AstHelper.NumberConstant(1), AstHelper.NumberConstant(2)));
+      var compiler = new Compiler();
+      var func = compiler.Compile(dict, _env, RunMode.Interactive);
+      string expected = (
+          $"Function <main>\n" +
+          $"  1    GETGLOB   0 {_printValFunc}                                  {_range}\n" +
+          $"  2    LOADK     2 -1             ; 1                 {_range}\n" +
+          $"  3    LOADK     3 -1             ; 1                 {_range}\n" +
+          $"  4    LOADK     4 -2             ; 2                 {_range}\n" +
+          $"  5    LOADK     5 -2             ; 2                 {_range}\n" +
+          $"  6    NEWDICT   1 2 4                                {_range}\n" +
+          $"  7    CALL      0 1 0                                {_range}\n" +
+          $"  8    RETURN    0 0                                  \n"
+      ).Replace("\n", Environment.NewLine);
+      Assert.Equal(expected, new Disassembler(func).ToString());
+    }
+
+    [Fact]
     public void TestCompileSubscript() {
       var subscript = AstHelper.ExpressionStmt(AstHelper.Subscript(
         AstHelper.List(AstHelper.NumberConstant(1),

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
@@ -764,7 +764,7 @@ namespace SeedLang.Interpreter.Tests {
 
     [Fact]
     public void TestCompileEmptyDict() {
-      var dict = AstHelper.ExpressionStmt(AstHelper.Dict(AstHelper.Keys()));
+      var dict = AstHelper.ExpressionStmt(AstHelper.Dict());
       var compiler = new Compiler();
       var func = compiler.Compile(dict, _env, RunMode.Interactive);
       string expected = (
@@ -780,8 +780,11 @@ namespace SeedLang.Interpreter.Tests {
     [Fact]
     public void TestCompileDict() {
       var dict = AstHelper.ExpressionStmt(
-        AstHelper.Dict(AstHelper.Keys(AstHelper.NumberConstant(1), AstHelper.NumberConstant(2)),
-                       AstHelper.NumberConstant(1), AstHelper.NumberConstant(2)));
+        AstHelper.Dict(
+          AstHelper.KeyValue(AstHelper.NumberConstant(1), AstHelper.NumberConstant(1)),
+          AstHelper.KeyValue(AstHelper.NumberConstant(2), AstHelper.NumberConstant(2))
+        )
+      );
       var compiler = new Compiler();
       var func = compiler.Compile(dict, _env, RunMode.Interactive);
       string expected = (

--- a/csharp/tests/SeedLang.Tests/Interpreter/DisassemblerTest.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/DisassemblerTest.cs
@@ -37,8 +37,8 @@ namespace SeedLang.Interpreter.Tests {
       string expected = (
           $"Function <main>\n" +
           $"  1    LOADK     0 -1             ; 1                 {_textRange}\n" +
-          $"  2    GETGLOB   1 -2             ; global_variable   {_textRange}\n" +
-          $"  3    SETGLOB   1 -3             ; name              {_textRange}\n" +
+          $"  2    GETGLOB   1 -2             ; 'global_variable' {_textRange}\n" +
+          $"  3    SETGLOB   1 -3             ; 'name'            {_textRange}\n" +
           $"  4    ADD       0 1 2                                {_textRange}\n" +
           $"  5    SUB       0 -4 2           ; 2                 {_textRange}\n" +
           $"  6    MUL       0 1 -5           ; 3                 {_textRange}\n" +

--- a/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
@@ -132,8 +132,11 @@ namespace SeedLang.Interpreter.Tests {
     [Fact]
     public void TestDict() {
       var program = AstHelper.ExpressionStmt(
-        AstHelper.Dict(AstHelper.Keys(AstHelper.NumberConstant(1), AstHelper.StringConstant("a")),
-                       AstHelper.NumberConstant(1), AstHelper.NumberConstant(2)));
+        AstHelper.Dict(
+          AstHelper.KeyValue(AstHelper.NumberConstant(1), AstHelper.NumberConstant(1)),
+          AstHelper.KeyValue(AstHelper.StringConstant("a"), AstHelper.NumberConstant(2))
+        )
+      );
       (string output, MockupVisualizer _) = Run(program);
       Assert.Equal("{1: 1, 'a': 2}" + Environment.NewLine, output);
     }

--- a/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
@@ -130,13 +130,22 @@ namespace SeedLang.Interpreter.Tests {
     }
 
     [Fact]
+    public void TestDict() {
+      var program = AstHelper.ExpressionStmt(
+        AstHelper.Dict(AstHelper.Keys(AstHelper.NumberConstant(1), AstHelper.StringConstant("a")),
+                       AstHelper.NumberConstant(1), AstHelper.NumberConstant(2)));
+      (string output, MockupVisualizer _) = Run(program);
+      Assert.Equal("{1: 1, 'a': 2}" + Environment.NewLine, output);
+    }
+
+    [Fact]
     public void TestTuple() {
       var program = AstHelper.ExpressionStmt(
         AstHelper.Tuple(AstHelper.NumberConstant(1),
                         AstHelper.NumberConstant(2),
                         AstHelper.NumberConstant(3))
       );
-      (string output, MockupVisualizer visualizer) = Run(program);
+      (string output, MockupVisualizer _) = Run(program);
       Assert.Equal("(1, 2, 3)" + Environment.NewLine, output);
     }
 

--- a/csharp/tests/SeedLang.Tests/Runtime/HeapObjectTests.cs
+++ b/csharp/tests/SeedLang.Tests/Runtime/HeapObjectTests.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using SeedLang.Common;
 using Xunit;
 
@@ -58,13 +58,22 @@ namespace SeedLang.Runtime.Tests {
 
     [Fact]
     public void TestTuple() {
-      var tuple = new HeapObject(new Value[] { new Value(1), new Value(2) });
+      var tuple = new HeapObject(ImmutableArray.Create<Value>());
+      Assert.Equal(0, tuple.Length);
+      Assert.Equal("()", tuple.AsString());
+
+      tuple = new HeapObject(ImmutableArray.Create(new Value(1), new Value(2)));
       Assert.Equal(2, tuple.Length);
       Assert.Equal(1, tuple[new Value(0)].AsNumber());
       Assert.Equal(2, tuple[new Value(1)].AsNumber());
       Assert.Equal("(1, 2)", tuple.AsString());
 
-      Assert.Throws<DiagnosticException>(() => tuple[new Value(1)] = new Value());
+      Assert.Equal(new HeapObject(ImmutableArray.Create(new Value(1), new Value(2))), tuple);
+      Assert.Equal(new HeapObject(ImmutableArray.Create(new Value(1), new Value(2))).GetHashCode(),
+                   tuple.GetHashCode());
+
+      var ex = Assert.Throws<DiagnosticException>(() => tuple[new Value(1)] = new Value());
+      Assert.Equal(Message.RuntimeErrorNotSupportAssignment, ex.Diagnostic.MessageId);
     }
   }
 }

--- a/csharp/tests/SeedLang.Tests/Runtime/HeapObjectTests.cs
+++ b/csharp/tests/SeedLang.Tests/Runtime/HeapObjectTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Generic;
 using SeedLang.Common;
 using Xunit;
 
@@ -24,7 +25,7 @@ namespace SeedLang.Runtime.Tests {
       var range = new HeapObject(new Range(10));
       Assert.Equal(10, range.Length);
       for (int i = 0; i < 10; i++) {
-        Assert.Equal(i, range[i].AsNumber());
+        Assert.Equal(i, range[new Value(i)].AsNumber());
       }
 
       int start = 3;
@@ -34,7 +35,7 @@ namespace SeedLang.Runtime.Tests {
       range = new HeapObject(new Range(start, stop, step));
       Assert.Equal(length, range.Length);
       for (int i = 0; i < length; i++) {
-        Assert.Equal(start + i * step, range[i].AsNumber());
+        Assert.Equal(start + i * step, range[new Value(i)].AsNumber());
       }
 
       start = 10;
@@ -44,7 +45,7 @@ namespace SeedLang.Runtime.Tests {
       range = new HeapObject(new Range(start, stop, step));
       Assert.Equal(length, range.Length);
       for (int i = 0; i < length; i++) {
-        Assert.Equal(start + i * step, range[i].AsNumber());
+        Assert.Equal(start + i * step, range[new Value(i)].AsNumber());
       }
 
       start = 1;
@@ -59,11 +60,11 @@ namespace SeedLang.Runtime.Tests {
     public void TestTuple() {
       var tuple = new HeapObject(new Value[] { new Value(1), new Value(2) });
       Assert.Equal(2, tuple.Length);
-      Assert.Equal(1, tuple[0].AsNumber());
-      Assert.Equal(2, tuple[1].AsNumber());
+      Assert.Equal(1, tuple[new Value(0)].AsNumber());
+      Assert.Equal(2, tuple[new Value(1)].AsNumber());
       Assert.Equal("(1, 2)", tuple.AsString());
 
-      Assert.Throws<DiagnosticException>(() => tuple[1] = new Value());
+      Assert.Throws<DiagnosticException>(() => tuple[new Value(1)] = new Value());
     }
   }
 }

--- a/csharp/tests/SeedLang.Tests/Runtime/NativeFunctionsTests.cs
+++ b/csharp/tests/SeedLang.Tests/Runtime/NativeFunctionsTests.cs
@@ -42,8 +42,8 @@ namespace SeedLang.Runtime.Tests {
       Value list = listFunc.Call(args, 0, args.Length, null);
       Assert.True(list.IsList);
       Assert.Equal(2, list.Length);
-      Assert.Equal(1, list[0].AsNumber());
-      Assert.Equal(2, list[1].AsNumber());
+      Assert.Equal(1, list[new Value(0)].AsNumber());
+      Assert.Equal(2, list[new Value(1)].AsNumber());
     }
 
     [Fact]
@@ -55,7 +55,7 @@ namespace SeedLang.Runtime.Tests {
       Assert.True(list.IsList);
       Assert.Equal(length, list.Length);
       for (int i = 0; i < length; i++) {
-        Assert.Equal(i, list[i].AsNumber());
+        Assert.Equal(i, list[new Value(i)].AsNumber());
       }
     }
 
@@ -65,7 +65,7 @@ namespace SeedLang.Runtime.Tests {
       var print = Function(NativeFunctions.Print);
       var args = new Value[] { new Value(1), new Value(2), new Value(3) };
       print.Call(args, 0, args.Length, sys);
-      var expected = $"1\n2\n3\n".Replace("\n", Environment.NewLine);
+      var expected = $"1 2 3\n".Replace("\n", Environment.NewLine);
       Assert.Equal(expected, sys.Stdout.ToString());
     }
 

--- a/csharp/tests/SeedLang.Tests/Runtime/ValueTests.cs
+++ b/csharp/tests/SeedLang.Tests/Runtime/ValueTests.cs
@@ -36,7 +36,7 @@ namespace SeedLang.Runtime.Tests {
 
       var exception1 = Assert.Throws<DiagnosticException>(() => nil.Length);
       Assert.Equal(Message.RuntimeErrorNotCountable, exception1.Diagnostic.MessageId);
-      var exception2 = Assert.Throws<DiagnosticException>(() => nil[0]);
+      var exception2 = Assert.Throws<DiagnosticException>(() => nil[new Value(0)]);
       Assert.Equal(Message.RuntimeErrorNotSubscriptable, exception2.Diagnostic.MessageId);
     }
 
@@ -58,7 +58,7 @@ namespace SeedLang.Runtime.Tests {
 
       var exception1 = Assert.Throws<DiagnosticException>(() => boolean.Length);
       Assert.Equal(Message.RuntimeErrorNotCountable, exception1.Diagnostic.MessageId);
-      var exception2 = Assert.Throws<DiagnosticException>(() => boolean[0]);
+      var exception2 = Assert.Throws<DiagnosticException>(() => boolean[new Value(0)]);
       Assert.Equal(Message.RuntimeErrorNotSubscriptable, exception2.Diagnostic.MessageId);
     }
 
@@ -80,7 +80,7 @@ namespace SeedLang.Runtime.Tests {
 
       var exception1 = Assert.Throws<DiagnosticException>(() => number.Length);
       Assert.Equal(Message.RuntimeErrorNotCountable, exception1.Diagnostic.MessageId);
-      var exception2 = Assert.Throws<DiagnosticException>(() => number[0]);
+      var exception2 = Assert.Throws<DiagnosticException>(() => number[new Value(0)]);
       Assert.Equal(Message.RuntimeErrorNotSubscriptable, exception2.Diagnostic.MessageId);
     }
 
@@ -91,27 +91,58 @@ namespace SeedLang.Runtime.Tests {
       Assert.False(str.AsBoolean());
       Assert.Equal(0, str.AsNumber());
       Assert.Equal("", str.AsString());
-      Assert.Equal("", str.ToString());
+      Assert.Equal("''", str.ToString());
 
       str = new Value(_expectedFalseString);
       Assert.True(str.IsString);
       Assert.True(str.AsBoolean());
       Assert.Equal(0, str.AsNumber());
       Assert.Equal(_expectedFalseString, str.AsString());
-      Assert.Equal(_expectedFalseString, str.ToString());
+      Assert.Equal($"'{_expectedFalseString}'", str.ToString());
 
       str = new Value(_expectedTrueString);
       Assert.True(str.IsString);
       Assert.True(str.AsBoolean());
       Assert.Equal(0, str.AsNumber());
       Assert.Equal(_expectedTrueString, str.AsString());
-      Assert.Equal(_expectedTrueString, str.ToString());
+      Assert.Equal($"'{_expectedTrueString}'", str.ToString());
 
       Assert.Equal(_expectedTrueString.Length, str.Length);
       for (int i = 0; i < _expectedTrueString.Length; i++) {
-        Assert.Equal(_expectedTrueString[i].ToString(), str[i].AsString());
+        Assert.Equal(_expectedTrueString[i].ToString(), str[new Value(i)].AsString());
       }
     }
+
+    [Fact]
+    public void TestDict() {
+      string str = "2";
+      Value tuple = new Value(new Value[] { new Value(1), new Value(2), });
+      var value = new Dictionary<Value, Value>() {
+        [new Value(1)] = new Value(1),
+        [new Value(str)] = new Value(2),
+        [tuple] = new Value(3),
+      };
+      var dict = new Value(value);
+      Assert.True(dict.IsDict);
+      Assert.Equal(3, dict.Length);
+      Assert.True(dict[new Value(1)].IsNumber);
+      Assert.Equal(1, dict[new Value(1)].AsNumber());
+      Assert.True(dict[new Value(str)].IsNumber);
+      Assert.Equal(2, dict[new Value(str)].AsNumber());
+      Assert.True(dict[tuple].IsNumber);
+      Assert.Equal(3, dict[tuple].AsNumber());
+      Assert.Equal("{1: 1, '2': 2, (1, 2): 3}", dict.AsString());
+
+      string testString = "test";
+      dict[new Value(1)] = new Value(testString);
+      Assert.True(dict[new Value(1)].IsString);
+      Assert.Equal(testString, dict[new Value(1)].AsString());
+      Assert.Equal("{1: 'test', '2': 2, (1, 2): 3}", dict.AsString());
+
+      dict[new Value()] = new Value(100);
+      Assert.Equal("{1: 'test', '2': 2, (1, 2): 3, None: 100}", dict.AsString());
+    }
+
 
     [Fact]
     public void TestList() {
@@ -123,17 +154,17 @@ namespace SeedLang.Runtime.Tests {
       var list = new Value(values);
       Assert.True(list.IsList);
       Assert.Equal(3, list.Length);
-      Assert.True(list[0].IsNumber);
-      Assert.Equal(1, list[0].AsNumber());
-      Assert.True(list[1].IsNumber);
-      Assert.Equal(2, list[1].AsNumber());
-      Assert.True(list[2].IsNumber);
-      Assert.Equal(3, list[2].AsNumber());
+      Assert.True(list[new Value(0)].IsNumber);
+      Assert.Equal(1, list[new Value(0)].AsNumber());
+      Assert.True(list[new Value(1)].IsNumber);
+      Assert.Equal(2, list[new Value(1)].AsNumber());
+      Assert.True(list[new Value(2)].IsNumber);
+      Assert.Equal(3, list[new Value(2)].AsNumber());
 
       string testString = "test";
-      list[1] = new Value(testString);
-      Assert.True(list[1].IsString);
-      Assert.Equal(testString, list[1].AsString());
+      list[new Value(1)] = new Value(testString);
+      Assert.True(list[new Value(1)].IsString);
+      Assert.Equal(testString, list[new Value(1)].AsString());
     }
 
     [Fact]
@@ -203,15 +234,34 @@ namespace SeedLang.Runtime.Tests {
     }
 
     [Fact]
-    public void TestListWithReferenceCycle() {
+    public void TestValueWithReferenceCycle() {
       var a = new Value(new List<Value>() {
         new Value(1),
         new Value(2),
       });
       var b = new Value(new List<Value>() { a });
-      a[1] = b;
+      a[new Value(1)] = b;
       Assert.Equal("[1, [[...]]]", a.ToString());
       Assert.Equal("[[1, [...]]]", b.ToString());
+
+      a = new Value(new Dictionary<Value, Value>());
+      b = new Value(new Dictionary<Value, Value>() {
+        [new Value("a")] = a,
+      });
+      a[new Value("b")] = b;
+      Assert.Equal("{'b': {'a': {...}}}", a.ToString());
+      Assert.Equal("{'a': {'b': {...}}}", b.ToString());
+
+      a = new Value(new List<Value>() {
+        new Value(1),
+        new Value(2),
+      });
+      b = new Value(new Dictionary<Value, Value>() {
+        [new Value("a")] = a,
+      });
+      a[new Value(1)] = b;
+      Assert.Equal("[1, {'a': [...]}]", a.ToString());
+      Assert.Equal("{'a': [1, {...}]}", b.ToString());
     }
   }
 }

--- a/csharp/tests/SeedLang.Tests/Runtime/ValueTests.cs
+++ b/csharp/tests/SeedLang.Tests/Runtime/ValueTests.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using SeedLang.Common;
 using Xunit;
 
@@ -116,7 +117,7 @@ namespace SeedLang.Runtime.Tests {
     [Fact]
     public void TestDict() {
       string str = "2";
-      Value tuple = new Value(new Value[] { new Value(1), new Value(2), });
+      var tuple = new Value(ImmutableArray.Create(new Value(1), new Value(2)));
       var value = new Dictionary<Value, Value>() {
         [new Value(1)] = new Value(1),
         [new Value(str)] = new Value(2),
@@ -141,8 +142,11 @@ namespace SeedLang.Runtime.Tests {
 
       dict[new Value()] = new Value(100);
       Assert.Equal("{1: 'test', '2': 2, (1, 2): 3, None: 100}", dict.AsString());
-    }
 
+      var ex = Assert.Throws<DiagnosticException>(() => {
+        dict[new Value(new List<Value>() { new Value(1) })] = new Value(2);
+      });
+    }
 
     [Fact]
     public void TestList() {
@@ -227,8 +231,8 @@ namespace SeedLang.Runtime.Tests {
                       new Value(new List<Value>() { new Value(2) }));
       Assert.NotEqual(new Value(new List<Value>() { new Value(1) }),
                       new Value(new List<Value>() { new Value(1), new Value(2) }));
-      Assert.NotEqual(new Value(new List<Value>() { new Value(1) }),
-                      new Value(new List<Value>() { new Value(1) }));
+      Assert.Equal(new Value(new List<Value>() { new Value(1) }),
+                   new Value(new List<Value>() { new Value(1) }));
       var list = new List<Value>() { new Value(1) };
       Assert.Equal(new Value(list), new Value(list));
     }

--- a/csharp/tests/SeedLang.Tests/Runtime/ValueTests.cs
+++ b/csharp/tests/SeedLang.Tests/Runtime/ValueTests.cs
@@ -143,9 +143,18 @@ namespace SeedLang.Runtime.Tests {
       dict[new Value()] = new Value(100);
       Assert.Equal("{1: 'test', '2': 2, (1, 2): 3, None: 100}", dict.AsString());
 
-      var ex = Assert.Throws<DiagnosticException>(() => {
+      var exception = Assert.Throws<DiagnosticException>(() => {
         dict[new Value(new List<Value>() { new Value(1) })] = new Value(2);
       });
+      Assert.Equal(Message.RuntimeErrorUnhashableType, exception.Diagnostic.MessageId);
+
+      exception = Assert.Throws<DiagnosticException>(() => {
+        var list = new Value(new List<Value>() { });
+        new Value(new Dictionary<Value, Value> {
+          [list] = new Value(),
+        });
+      });
+      Assert.Equal(Message.RuntimeErrorUnhashableType, exception.Diagnostic.MessageId);
     }
 
     [Fact]

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonDictTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonDictTests.cs
@@ -1,0 +1,69 @@
+// Copyright 2021-2022 The SeedV Lab.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using SeedLang.Ast;
+using SeedLang.Common;
+using Xunit;
+
+namespace SeedLang.X.Tests {
+  public class SeedPythonDictTests {
+    [Fact]
+    public void TestEmptyDict() {
+      string source = "{}";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 1] ExpressionStatement\n" +
+                        "  [Ln 1, Col 0 - Ln 1, Col 1] DictExpression";
+      string expectedTokens = "OpenBrace [Ln 1, Col 0 - Ln 1, Col 0]," +
+                              "CloseBrace [Ln 1, Col 1 - Ln 1, Col 1]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
+
+    [Fact]
+    public void TestDict() {
+      string source = "{'a': 1, 'b': 2, 'c': 3}";
+      string expected = "[Ln 1, Col 0 - Ln 1, Col 23] ExpressionStatement\n" +
+                        "  [Ln 1, Col 0 - Ln 1, Col 23] DictExpression\n" +
+                        "    [Ln 1, Col 1 - Ln 1, Col 3] StringConstantExpression (a)\n" +
+                        "    [Ln 1, Col 6 - Ln 1, Col 6] NumberConstantExpression (1)\n" +
+                        "    [Ln 1, Col 9 - Ln 1, Col 11] StringConstantExpression (b)\n" +
+                        "    [Ln 1, Col 14 - Ln 1, Col 14] NumberConstantExpression (2)\n" +
+                        "    [Ln 1, Col 17 - Ln 1, Col 19] StringConstantExpression (c)\n" +
+                        "    [Ln 1, Col 22 - Ln 1, Col 22] NumberConstantExpression (3)";
+      string expectedTokens = "OpenBrace [Ln 1, Col 0 - Ln 1, Col 0]," +
+                              "String [Ln 1, Col 1 - Ln 1, Col 3]," +
+                              "Symbol [Ln 1, Col 4 - Ln 1, Col 4]," +
+                              "Number [Ln 1, Col 6 - Ln 1, Col 6]," +
+                              "String [Ln 1, Col 9 - Ln 1, Col 11]," +
+                              "Symbol [Ln 1, Col 12 - Ln 1, Col 12]," +
+                              "Number [Ln 1, Col 14 - Ln 1, Col 14]," +
+                              "String [Ln 1, Col 17 - Ln 1, Col 19]," +
+                              "Symbol [Ln 1, Col 20 - Ln 1, Col 20]," +
+                              "Number [Ln 1, Col 22 - Ln 1, Col 22]," +
+                              "CloseBrace [Ln 1, Col 23 - Ln 1, Col 23]";
+      TestPythonParser(source, expected, expectedTokens);
+    }
+
+    private static void TestPythonParser(string source, string expected, string expectedTokens) {
+      var collection = new DiagnosticCollection();
+      var parser = new SeedPython();
+      Assert.True(parser.Parse(source, "", collection, out AstNode node,
+                               out IReadOnlyList<TokenInfo> tokens));
+      Assert.NotNull(node);
+      Assert.Empty(collection.Diagnostics);
+      Assert.Equal(expected, node.ToString());
+      Assert.Equal(expectedTokens, string.Join(",", tokens.Select(token => token.ToString())));
+    }
+  }
+}

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonErrorTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonErrorTests.cs
@@ -35,7 +35,7 @@ namespace SeedLang.X.Tests {
     [InlineData("1 +",
                 new string[] {
                   @"SyntaxErrorInputMismatch '\n' " +
-                  @"{'True', 'False', 'None', '+', '-', '(', '[', NAME, NUMBER, STRING}",
+                  @"{'True', 'False', 'None', '+', '-', '(', '[', '{', NAME, NUMBER, STRING}",
                 },
 
                 "Number [Ln 1, Col 0 - Ln 1, Col 0]," +
@@ -86,7 +86,7 @@ namespace SeedLang.X.Tests {
     [InlineData("1 + ))",
                 new string[] {
                   "SyntaxErrorInputMismatch ')' " +
-                  "{'True', 'False', 'None', '+', '-', '(', '[', NAME, NUMBER, STRING}",
+                  "{'True', 'False', 'None', '+', '-', '(', '[', '{', NAME, NUMBER, STRING}",
                 },
 
                 "Number [Ln 1, Col 0 - Ln 1, Col 0]," +
@@ -97,7 +97,7 @@ namespace SeedLang.X.Tests {
     [InlineData("1 < 2 >=",
                 new string[] {
                   @"SyntaxErrorInputMismatch '\n' " +
-                  @"{'True', 'False', 'None', '+', '-', '(', '[', NAME, NUMBER, STRING}",
+                  @"{'True', 'False', 'None', '+', '-', '(', '[', '{', NAME, NUMBER, STRING}",
                 },
 
                 "Number [Ln 1, Col 0 - Ln 1, Col 0]," +

--- a/design/seed_vm.md
+++ b/design/seed_vm.md
@@ -105,28 +105,29 @@ All the SeedLang instructions are listed as follows:
 |   5    | `SETGLOB`  | Write a register value into a global variable       |
 |   6    | `NEWTUPLE` | Create a new tuple with the initial elements        |
 |   7    | `NEWLIST`  | Create a new list with the initial elements         |
-|   8    | `GETELEM`  | Read a list or table element into a register        |
-|   9    | `SETELEM`  | Write a register value into a list or table element |
-|   10   | `ADD`      | Addition operation                                  |
-|   11   | `SUB`      | Subtract operation                                  |
-|   12   | `MUL`      | Multiply operation                                  |
-|   13   | `DIV`      | Divide operation                                    |
-|   14   | `FLOORDIV` | Floor Divide operation                              |
-|   15   | `POW`      | Exponentiation operation                            |
-|   16   | `MOD`      | Modulus (reminder) operation                        |
-|   17   | `UNM`      | Unary minus operation                               |
-|   18   | `NOT`      | Logical not operation                               |
-|   19   | `LEN`      | Length operation                                    |
-|   20   | `JMP`      | Unconditional jump                                  |
-|   21   | `EQ`       | Equality test                                       |
-|   22   | `LT`       | Less than test                                      |
-|   23   | `LE`       | Less than or equal to test                          |
-|   24   | `TEST`     | Boolean test, with conditional jump                 |
-|   25   | `TESTSET`  | Boolean test, with conditional jump and assignment  |
-|   26   | `FORPREP`  | For loop preparation                                |
-|   27   | `FORLOOP`  | For loop check                                      |
-|   28   | `CALL`     | Call a function                                     |
-|   29   | `RETURN`   | Return from a function call                         |
+|   8    | `NEWDICT`  | Create a new dict with the initial keys and values  |
+|   9    | `GETELEM`  | Read a list or table element into a register        |
+|   10   | `SETELEM`  | Write a register value into a list or table element |
+|   11   | `ADD`      | Addition operation                                  |
+|   12   | `SUB`      | Subtract operation                                  |
+|   13   | `MUL`      | Multiply operation                                  |
+|   14   | `DIV`      | Divide operation                                    |
+|   15   | `FLOORDIV` | Floor Divide operation                              |
+|   16   | `POW`      | Exponentiation operation                            |
+|   17   | `MOD`      | Modulus (reminder) operation                        |
+|   18   | `UNM`      | Unary minus operation                               |
+|   19   | `NOT`      | Logical not operation                               |
+|   20   | `LEN`      | Length operation                                    |
+|   21   | `JMP`      | Unconditional jump                                  |
+|   22   | `EQ`       | Equality test                                       |
+|   23   | `LT`       | Less than test                                      |
+|   24   | `LE`       | Less than or equal to test                          |
+|   25   | `TEST`     | Boolean test, with conditional jump                 |
+|   26   | `TESTSET`  | Boolean test, with conditional jump and assignment  |
+|   27   | `FORPREP`  | For loop preparation                                |
+|   28   | `FORLOOP`  | For loop check                                      |
+|   29   | `CALL`     | Call a function                                     |
+|   30   | `RETURN`   | Return from a function call                         |
 
 ### Move and Load Constant
 
@@ -168,6 +169,8 @@ NEWTUPLE A B C          # R(A) := (R(B), R(B+1), ..., R(B+C-1)), C is the count
                         # of initial elements
 NEWLIST A B C           # R(A) := [R(B), R(B+1), ..., R(B+C-1)], C is the count
                         # of initial elements
+NEWDICT A B C           # R(A) := {R(B): R(B+1), ..., R(B+C-2): R(B+C-1)], C is
+                        # the count of initial keys and values
 GETELEM A B C           # R(A) := R(B)[RK(C)]
 SETELEM A B C           # R(A)[RK(B)] := RK(C)
 ```

--- a/examples/seedpython/scripts/dict.py
+++ b/examples/seedpython/scripts/dict.py
@@ -1,0 +1,10 @@
+dict = {'Name': 'Zara', 'Age': 7, 'Class': 'First'}
+
+print("dict['Name']:", dict['Name'])  # dict['Name']: Zara
+print("dict['Age']:", dict['Age'])  # "dict['Age']: 7
+
+dict['Age'] = 8
+dict['School'] = "DPS School"
+
+print("dict['Age']:", dict['Age'])  # dict['Age']: 8
+print("dict['School']:", dict['School'])  # dict['School']: DPS School

--- a/grammars/Common.g4
+++ b/grammars/Common.g4
@@ -78,6 +78,7 @@ atom:
   | NUMBER   # number
   | STRING+  # strings
   | group    # group_as_atom
+  | dict     # dict_as_atom
   | list     # list_as_atom
   | tuple    # tuple_as_atom;
 
@@ -87,9 +88,14 @@ arguments: expression (COMMA expression)*;
 
 group: OPEN_PAREN expression CLOSE_PAREN;
 
+dict: OPEN_BRACE kvpairs? CLOSE_BRACE;
+
 list: OPEN_BRACK expressions? CLOSE_BRACK;
 
 tuple: OPEN_PAREN expressions? CLOSE_PAREN;
+
+kvpairs: kvpair (COMMA kvpair)*;
+kvpair: expression COLON expression;
 
 /*
  * Lexer rules
@@ -135,6 +141,7 @@ CLOSE_BRACE: '}';
 
 DOT: '.';
 COMMA: ',';
+COLON: ':';
 
 NAME: ID_START ID_CONTINUE*;
 

--- a/grammars/SeedPython.g4
+++ b/grammars/SeedPython.g4
@@ -101,5 +101,4 @@ DEF: 'def';
 RETURN: 'return';
 PASS: 'pass';
 
-COLON: ':';
 SEMICOLON: ';';


### PR DESCRIPTION
- Implement Dict for SeedPython, support following code now

```python
dict = {'Name': 'Zara', 'Age': 7, 'Class': 'First'}

print("dict['Name']:", dict['Name'])  # dict['Name']: Zara
print("dict['Age']:", dict['Age'])  # "dict['Age']: 7

dict['Age'] = 8
dict['School'] = "DPS School"

print("dict['Age']:", dict['Age'])  # dict['Age']: 8
print("dict['School']:", dict['School'])  # dict['School']: DPS School
```

- Change the underlying data structure of Tuple to support hash code calculation for Dict.