### PR TITLE
Change coverage service from coveralls.io to Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: Coverage
 
 on:
   push:
-    branches: [main]
+    branches: [wip_codingpotato_codecov]
   workflow_dispatch:
 
 jobs:
@@ -25,9 +25,6 @@ jobs:
         working-directory: ./csharp
         run: |
           dotnet test /p:CollectCoverage=true /p:CoverletOutput=TestResults/ \
-          /p:CoverletOutputFormat=lcov /p:ExcludeByFile="**/obj/**/*.cs"
-      - name: Publish coverage report to coveralls.io
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./csharp/tests/SeedLang.Tests/TestResults/coverage.info
+          /p:CoverletOutputFormat=opencover /p:ExcludeByFile="**/obj/**/*.cs"
+      - name: Codecov
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: Coverage
 
 on:
   push:
-    branches: [wip_codingpotato_codecov]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # SeedLang
 
 ![build](https://github.com/SeedV/SeedLang/actions/workflows/csharp.yml/badge.svg)
-[![Coverage
-Status](https://coveralls.io/repos/github/SeedV/SeedLang/badge.svg?branch=main)](https://coveralls.io/github/SeedV/SeedLang?branch=main)
+[![codecov](https://codecov.io/gh/SeedV/SeedLang/branch/main/graph/badge.svg?token=B8M1QLS0MT)](https://codecov.io/gh/SeedV/SeedLang)
 
 SeedLang is a visualizable low-code programming environment that focuses on
 educational purposes.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # SeedLang
 
+![build](https://github.com/SeedV/SeedLang/actions/workflows/csharp.yml/badge.svg)
 [![Coverage
 Status](https://coveralls.io/repos/github/SeedV/SeedLang/badge.svg?branch=main)](https://coveralls.io/github/SeedV/SeedLang?branch=main)
 


### PR DESCRIPTION
Change to Codecov, because it has more features than coveralls.io. And also add a badge for Github build pass.

When comparing Coveralls vs Codecov, the Slant community recommends Codecov for most people. In the question“What are the best code coverage services?” Codecov is ranked 1st while Coveralls is ranked 3rd. The most important reason people chose Codecov is:
Codecov is free for up to 5 users and open source repositories on Github, Bitbucket, and Gitlab.