### PR TITLE
Implement chained assignment statement

### DIFF
--- a/csharp/src/SeedLang/Ast/AstDumper.cs
+++ b/csharp/src/SeedLang/Ast/AstDumper.cs
@@ -242,8 +242,11 @@ namespace SeedLang.Ast {
       }
 
       protected override void VisitAssignment(AssignmentStatement assignment) {
-        foreach (Expression expr in assignment.Targets) {
-          _exprDumper.Visit(expr);
+        foreach (Expression[] targets in assignment.Targets) {
+          foreach (Expression target in targets) {
+            _exprDumper.Visit(target);
+          }
+          _builder.Append(" =");
         }
         foreach (Expression expr in assignment.Exprs) {
           _exprDumper.Visit(expr);

--- a/csharp/src/SeedLang/Ast/AstDumper.cs
+++ b/csharp/src/SeedLang/Ast/AstDumper.cs
@@ -248,7 +248,7 @@ namespace SeedLang.Ast {
           }
           _builder.Append(" =");
         }
-        foreach (Expression expr in assignment.Exprs) {
+        foreach (Expression expr in assignment.Values) {
           _exprDumper.Visit(expr);
         }
       }

--- a/csharp/src/SeedLang/Ast/Statements.cs
+++ b/csharp/src/SeedLang/Ast/Statements.cs
@@ -88,17 +88,20 @@ namespace SeedLang.Ast {
   }
 
   internal class AssignmentStatement : Statement {
-    // The targets of assignment statements. The class of each target could be IdentifierExpression
-    // or SubscriptExpression.
+    // The targets of assignment statements.
+    //
+    // It's a 2-dimension array. The first dimension is for chained assignments and the second one
+    // is for multiple targets assignment. e.g. "a, b = x, y = 1, 2". The class of each target could
+    // be IdentifierExpression or SubscriptExpression.
     public Expression[][] Targets { get; }
-    // The right values of assignment statements. The lengths of targets and exprs are not necessary
-    // to be the same.
-    public Expression[] Exprs { get; }
 
-    internal AssignmentStatement(Expression[][] targets, Expression[] exprs, TextRange range) :
+    // The right values of assignment statements.
+    public Expression[] Values { get; }
+
+    internal AssignmentStatement(Expression[][] targets, Expression[] values, TextRange range) :
         base(range) {
       Targets = targets;
-      Exprs = exprs;
+      Values = values;
     }
   }
 

--- a/csharp/src/SeedLang/Ast/Statements.cs
+++ b/csharp/src/SeedLang/Ast/Statements.cs
@@ -20,7 +20,7 @@ namespace SeedLang.Ast {
   // The base class of all statement nodes.
   internal abstract class Statement : AstNode {
     // The factory method to create assignment statements.
-    internal static AssignmentStatement Assignment(Expression[] targets, Expression[] exprs,
+    internal static AssignmentStatement Assignment(Expression[][] targets, Expression[] exprs,
                                                    TextRange range) {
       return new AssignmentStatement(targets, exprs, range);
     }
@@ -90,12 +90,12 @@ namespace SeedLang.Ast {
   internal class AssignmentStatement : Statement {
     // The targets of assignment statements. The class of each target could be IdentifierExpression
     // or SubscriptExpression.
-    public Expression[] Targets { get; }
+    public Expression[][] Targets { get; }
     // The right values of assignment statements. The lengths of targets and exprs are not necessary
     // to be the same.
     public Expression[] Exprs { get; }
 
-    internal AssignmentStatement(Expression[] targets, Expression[] exprs, TextRange range) :
+    internal AssignmentStatement(Expression[][] targets, Expression[] exprs, TextRange range) :
         base(range) {
       Targets = targets;
       Exprs = exprs;

--- a/csharp/src/SeedLang/Interpreter/Compiler.cs
+++ b/csharp/src/SeedLang/Interpreter/Compiler.cs
@@ -52,9 +52,10 @@ namespace SeedLang.Interpreter {
 
     protected override void VisitAssignment(AssignmentStatement assignment) {
       if (assignment.Exprs.Length == 1) {
-        Unpack(assignment.Targets, assignment.Exprs[0], assignment.Range);
+        // TODO: implement chained assignment.
+        Unpack(assignment.Targets[0], assignment.Exprs[0], assignment.Range);
       } else {
-        Pack(assignment.Targets, assignment.Exprs, assignment.Range);
+        Pack(assignment.Targets[0], assignment.Exprs, assignment.Range);
       }
     }
 

--- a/csharp/src/SeedLang/SeedLang.csproj
+++ b/csharp/src/SeedLang/SeedLang.csproj
@@ -24,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.9.2" />
-    <PackageReference Include="Antlr4BuildTasks" Version="8.15">
+    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.10.1" />
+    <PackageReference Include="Antlr4BuildTasks" Version="10.4.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/csharp/src/SeedLang/SeedLang.csproj
+++ b/csharp/src/SeedLang/SeedLang.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.10.1" />
-    <PackageReference Include="Antlr4BuildTasks" Version="10.4.0">
+    <PackageReference Include="Antlr4BuildTasks" Version="10.4">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/csharp/src/SeedLang/SeedLang.csproj
+++ b/csharp/src/SeedLang/SeedLang.csproj
@@ -24,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.10" />
-    <PackageReference Include="Antlr4BuildTasks" Version="10.1">
+    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.9.2" />
+    <PackageReference Include="Antlr4BuildTasks" Version="8.15">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/csharp/src/SeedLang/SeedLang.csproj
+++ b/csharp/src/SeedLang/SeedLang.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.10.1" />
-    <PackageReference Include="Antlr4BuildTasks" Version="10.4">
+    <PackageReference Include="Antlr4BuildTasks" Version="10.3.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/csharp/src/SeedLang/SeedLang.csproj
+++ b/csharp/src/SeedLang/SeedLang.csproj
@@ -24,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.10.1" />
-    <PackageReference Include="Antlr4BuildTasks" Version="10.3.0">
+    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.10" />
+    <PackageReference Include="Antlr4BuildTasks" Version="10.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/csharp/src/SeedLang/X/SeedPythonVisitor.cs
+++ b/csharp/src/SeedLang/X/SeedPythonVisitor.cs
@@ -84,10 +84,15 @@ namespace SeedLang.X {
     }
 
     public override AstNode VisitAssign([NotNull] SeedPythonParser.AssignContext context) {
-      SeedPythonParser.TargetsContext targets = context.targets();
+      Debug.Assert(context.targets().Length == context.EQUAL().Length);
+      int length = context.targets().Length;
+      var targetsInfo = new (ParserRuleContext[], ITerminalNode[], IToken)[length];
+      for (int i = 0; i < length; i++) {
+        SeedPythonParser.TargetsContext targets = context.targets()[i];
+        targetsInfo[i] = (targets.target(), targets.COMMA(), context.EQUAL()[i].Symbol);
+      }
       SeedPythonParser.ExpressionsContext exprs = context.expressions();
-      return _helper.BuildAssignment(targets.target(), targets.COMMA(), context.EQUAL().Symbol,
-                                     exprs.expression(), exprs.COMMA(), this);
+      return _helper.BuildAssignment(targetsInfo, exprs.expression(), exprs.COMMA(), this);
     }
 
     public override AstNode VisitAdd_assign([NotNull] SeedPythonParser.Add_assignContext context) {

--- a/csharp/tests/SeedLang.Tests/Ast/StatementsTest.cs
+++ b/csharp/tests/SeedLang.Tests/Ast/StatementsTest.cs
@@ -34,11 +34,13 @@ namespace SeedLang.Ast.Tests {
 
       private void AddAssignment() {
         string name = "id";
-        var assignment = AstHelper.Assign(AstHelper.Targets(AstHelper.Id(name)),
-                                          AstHelper.NumberConstant(1));
+        var assignment = AstHelper.Assign(
+          AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(name))),
+          AstHelper.NumberConstant(1)
+        );
         var expectedOutput = (
             $"{AstHelper.TextRange} AssignmentStatement\n" +
-            $"  {AstHelper.TextRange} IdentifierExpression ({name})\n" +
+            $"  {AstHelper.TextRange} IdentifierExpression ({name}) =\n" +
             $"  {AstHelper.TextRange} NumberConstantExpression (1)"
         ).Replace("\n", Environment.NewLine);
         Add(assignment, expectedOutput);
@@ -97,19 +99,21 @@ namespace SeedLang.Ast.Tests {
 
       private void AddIf() {
         string name = "id";
-        var @if = AstHelper.If(AstHelper.BooleanConstant(false),
-                               AstHelper.Assign(AstHelper.Targets(AstHelper.Id(name)),
-                                                AstHelper.NumberConstant(1)),
-                               AstHelper.Assign(AstHelper.Targets(AstHelper.Id(name)),
-                                                AstHelper.NumberConstant(2)));
+        var @if = AstHelper.If(
+          AstHelper.BooleanConstant(false),
+          AstHelper.Assign(AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(name))),
+                           AstHelper.NumberConstant(1)),
+          AstHelper.Assign(AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(name))),
+                           AstHelper.NumberConstant(2))
+        );
         var expectedOutput = (
             $"{AstHelper.TextRange} IfStatement\n" +
             $"  {AstHelper.TextRange} BooleanConstantExpression (False)\n" +
             $"  {AstHelper.TextRange} AssignmentStatement\n" +
-            $"    {AstHelper.TextRange} IdentifierExpression ({name})\n" +
+            $"    {AstHelper.TextRange} IdentifierExpression ({name}) =\n" +
             $"    {AstHelper.TextRange} NumberConstantExpression (1)\n" +
             $"  {AstHelper.TextRange} AssignmentStatement\n" +
-            $"    {AstHelper.TextRange} IdentifierExpression ({name})\n" +
+            $"    {AstHelper.TextRange} IdentifierExpression ({name}) =\n" +
             $"    {AstHelper.TextRange} NumberConstantExpression (2)"
         ).Replace("\n", Environment.NewLine);
         Add(@if, expectedOutput);
@@ -132,14 +136,16 @@ namespace SeedLang.Ast.Tests {
 
       private void AddWhile() {
         string name = "id";
-        var @while = AstHelper.While(AstHelper.BooleanConstant(true),
-                                     AstHelper.Assign(AstHelper.Targets(AstHelper.Id(name)),
-                                                      AstHelper.NumberConstant(1)));
+        var @while = AstHelper.While(
+          AstHelper.BooleanConstant(true),
+          AstHelper.Assign(AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(name))),
+                           AstHelper.NumberConstant(1))
+        );
         var expectedOutput = (
             $"{AstHelper.TextRange} WhileStatement\n" +
             $"  {AstHelper.TextRange} BooleanConstantExpression (True)\n" +
             $"  {AstHelper.TextRange} AssignmentStatement\n" +
-            $"    {AstHelper.TextRange} IdentifierExpression ({name})\n" +
+            $"    {AstHelper.TextRange} IdentifierExpression ({name}) =\n" +
             $"    {AstHelper.TextRange} NumberConstantExpression (1)"
         ).Replace("\n", Environment.NewLine);
         Add(@while, expectedOutput);

--- a/csharp/tests/SeedLang.Tests/Helper/AstHelper.cs
+++ b/csharp/tests/SeedLang.Tests/Helper/AstHelper.cs
@@ -21,8 +21,12 @@ namespace SeedLang.Tests.Helper {
   internal class AstHelper {
     public static readonly TextRange TextRange = new TextRange(0, 1, 2, 3);
 
-    internal static AssignmentStatement Assign(Expression[] targets, params Expression[] exprs) {
+    internal static AssignmentStatement Assign(Expression[][] targets, params Expression[] exprs) {
       return Statement.Assignment(targets, exprs, TextRange);
+    }
+
+    internal static Expression[][] ChainedTargets(params Expression[][] targets) {
+      return targets;
     }
 
     internal static Expression[] Targets(params Expression[] targets) {

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
@@ -37,7 +37,7 @@ namespace SeedLang.Interpreter.Tests {
       string source = "name = 1";
       string expected = (
         $"Function <main>\n" +
-        $"  1    LOADK     0 -1             ; 1                 [Ln 1, Col 0 - Ln 1, Col 7]\n" +
+        $"  1    LOADK     0 -1             ; 1                 [Ln 1, Col 7 - Ln 1, Col 7]\n" +
         $"  2    SETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 1, Col 0 - Ln 1, Col 7]\n" +
         $"  3    VISNOTIFY 0 0                                  [Ln 1, Col 0 - Ln 1, Col 7]\n" +
@@ -130,11 +130,11 @@ print(sum)
         $"  3    SETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 2, Col 0 - Ln 3, Col 13]\n" +
         $"  4    VISNOTIFY 0 0                                  [Ln 5, Col 0 - Ln 5, Col 0]\n" +
-        $"  5    LOADK     0 -2             ; 0                 [Ln 5, Col 0 - Ln 5, Col 6]\n" +
+        $"  5    LOADK     0 -2             ; 0                 [Ln 5, Col 6 - Ln 5, Col 6]\n" +
         $"  6    SETGLOB   0 {_firstGlob + 1}" +
         $"                                  [Ln 5, Col 0 - Ln 5, Col 6]\n" +
         $"  7    VISNOTIFY 0 0                                  [Ln 6, Col 0 - Ln 6, Col 0]\n" +
-        $"  8    LOADK     0 -2             ; 0                 [Ln 6, Col 0 - Ln 6, Col 4]\n" +
+        $"  8    LOADK     0 -2             ; 0                 [Ln 6, Col 4 - Ln 6, Col 4]\n" +
         $"  9    SETGLOB   0 {_firstGlob + 2}" +
         $"                                  [Ln 6, Col 0 - Ln 6, Col 4]\n" +
         $"  10   VISNOTIFY 0 0                                  [Ln 7, Col 0 - Ln 7, Col 0]\n" +
@@ -213,7 +213,7 @@ flag = \
       string expected = (
         $"Function <main>\n" +
         $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 2, Col 0]\n" +
-        $"  2    LOADK     0 -1             ; 0                 [Ln 2, Col 0 - Ln 2, Col 4]\n" +
+        $"  2    LOADK     0 -1             ; 0                 [Ln 2, Col 4 - Ln 2, Col 4]\n" +
         $"  3    SETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 2, Col 0 - Ln 2, Col 4]\n" +
         $"  4    VISNOTIFY 0 0                                  [Ln 4, Col 0 - Ln 4, Col 0]\n" +
@@ -256,7 +256,7 @@ x = 1
         $"Function <main>\n" +
         $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 3, Col 4]\n" +
         $"  2    VISNOTIFY 0 1                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
-        $"  3    LOADK     0 -1             ; 1                 [Ln 3, Col 0 - Ln 3, Col 4]\n" +
+        $"  3    LOADK     0 -1             ; 1                 [Ln 3, Col 4 - Ln 3, Col 4]\n" +
         $"  4    SETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
         $"  5    GETGLOB   0 {_firstGlob}" +
@@ -330,13 +330,12 @@ def func():
         $"  3    HALT      1 0                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
         $"\n" +
         $"Function <func>\n" +
-        $"  1    LOADK     2 -1             ; 1                 [Ln 3, Col 7 - Ln 3, Col 7]\n" +
-        $"  2    LOADK     3 -2             ; 2                 [Ln 3, Col 10 - Ln 3, Col 10]\n" +
-        $"  3    NEWLIST   1 2 2                                [Ln 3, Col 6 - Ln 3, Col 11]\n" +
-        $"  4    MOVE      0 1                                  [Ln 3, Col 2 - Ln 3, Col 11]\n" +
-        $"  5    SETELEM   0 -1 -1          ; 1 1               [Ln 4, Col 2 - Ln 4, Col 9]\n" +
-        $"  6    VISNOTIFY 0 0                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
-        $"  7    RETURN    0 0                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
+        $"  1    LOADK     1 -1             ; 1                 [Ln 3, Col 7 - Ln 3, Col 7]\n" +
+        $"  2    LOADK     2 -2             ; 2                 [Ln 3, Col 10 - Ln 3, Col 10]\n" +
+        $"  3    NEWLIST   0 1 2                                [Ln 3, Col 6 - Ln 3, Col 11]\n" +
+        $"  4    SETELEM   0 -1 -1          ; 1 1               [Ln 4, Col 2 - Ln 4, Col 9]\n" +
+        $"  5    VISNOTIFY 0 0                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
+        $"  6    RETURN    0 0                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
         $"Notifications\n" +
         $"  0    Notification.SubscriptAssignment: 'global.func.a': Local 250 250\n"
       ).Replace("\n", Environment.NewLine);
@@ -428,27 +427,32 @@ x, y = 1, 1 + 2
         $"Function <main>\n" +
         $"  1    ADD       2 -1 -2          ; 1 2               [Ln 2, Col 21 - Ln 2, Col 25]\n" +
         $"  2    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 4, Col 3]\n" +
-        $"  3    ADD       0 -1 -2          ; 1 2               [Ln 3, Col 10 - Ln 3, Col 14]\n" +
-        $"  4    VISNOTIFY 0 1                                  [Ln 3, Col 10 - Ln 3, Col 14]\n" +
-        $"  5    LOADK     1 -1             ; 1                 [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  6    SETGLOB   1 {_firstGlob}" +
+        $"  3    LOADK     1 -1             ; 1                 [Ln 3, Col 7 - Ln 3, Col 7]\n" +
+        $"  4    ADD       2 -1 -2          ; 1 2               [Ln 3, Col 10 - Ln 3, Col 14]\n" +
+        $"  5    VISNOTIFY 0 1                                  [Ln 3, Col 10 - Ln 3, Col 14]\n" +
+        $"  6    NEWTUPLE  0 1 2                                [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  7    LOADK     2 -3             ; 0                 [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  8    GETELEM   1 0 2                                [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  9    SETGLOB   1 {_firstGlob}" +
         $"                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  7    VISNOTIFY 0 2                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  8    SETGLOB   0 {_firstGlob + 1}" +
+        $"  10   VISNOTIFY 0 2                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  11   LOADK     2 -1             ; 1                 [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  12   GETELEM   1 0 2                                [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  13   SETGLOB   1 {_firstGlob + 1}" +
         $"                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  9    VISNOTIFY 0 3                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  10   GETGLOB   0 {_firstGlob}" +
+        $"  14   VISNOTIFY 0 3                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  15   GETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 2, Col 12 - Ln 2, Col 12]\n" +
-        $"  11   GETGLOB   1 {_firstGlob + 1}" +
+        $"  16   GETGLOB   1 {_firstGlob + 1}" +
         $"                                  [Ln 2, Col 18 - Ln 2, Col 18]\n" +
-        $"  12   ADD       2 -1 -2          ; 1 2               [Ln 2, Col 21 - Ln 2, Col 25]\n" +
-        $"  13   VISNOTIFY 0 4                                  [Ln 2, Col 0 - Ln 4, Col 3]\n" +
-        $"  14   HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  17   ADD       2 -1 -2          ; 1 2               [Ln 2, Col 21 - Ln 2, Col 25]\n" +
+        $"  18   VISNOTIFY 0 4                                  [Ln 2, Col 0 - Ln 4, Col 3]\n" +
+        $"  19   HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
         $"Notifications\n" +
         $"  0    Notification.VTagEntered: Assign(x: null, 1: 250, y: null, 1+2: 2)\n" +
-        $"  1    Notification.Binary: 250 Add 251 0\n" +
+        $"  1    Notification.Binary: 250 Add 251 2\n" +
         $"  2    Notification.Assignment: 'global.x': Global 1\n" +
-        $"  3    Notification.Assignment: 'global.y': Global 0\n" +
+        $"  3    Notification.Assignment: 'global.y': Global 1\n" +
         $"  4    Notification.VTagExited: Assign(x: 0, 1: 250, y: 1, 1+2: 2)\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] {

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
@@ -33,8 +33,10 @@ namespace SeedLang.Interpreter.Tests {
 
     [Fact]
     public void TestCompileAssignment() {
-      var program = AstHelper.Assign(AstHelper.Targets(AstHelper.Id("name")),
-                                                       AstHelper.NumberConstant(1));
+      var program = AstHelper.Assign(
+        AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id("name"))),
+        AstHelper.NumberConstant(1)
+      );
       string expected = (
           $"Function <main>\n" +
           $"  1    LOADK     0 -1             ; 1                 {_range}\n" +
@@ -46,8 +48,11 @@ namespace SeedLang.Interpreter.Tests {
 
     [Fact]
     public void TestCompileMultipleAssignment() {
-      var program = AstHelper.Assign(AstHelper.Targets(AstHelper.Id("x"), AstHelper.Id("y")),
-                                     AstHelper.NumberConstant(1), AstHelper.NumberConstant(2));
+      var program = AstHelper.Assign(
+        AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id("x"), AstHelper.Id("y"))),
+        AstHelper.NumberConstant(1),
+        AstHelper.NumberConstant(2)
+      );
       string expected = (
           $"Function <main>\n" +
           $"  1    LOADK     0 -1             ; 1                 {_range}\n" +
@@ -62,7 +67,7 @@ namespace SeedLang.Interpreter.Tests {
     [Fact]
     public void TestCompileAssignBinary() {
       var program = AstHelper.Assign(
-        AstHelper.Targets(AstHelper.Id("name")),
+        AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id("name"))),
         AstHelper.Binary(AstHelper.NumberConstant(1), BinaryOperator.Add,
                          AstHelper.NumberConstant(2))
       );
@@ -79,7 +84,7 @@ namespace SeedLang.Interpreter.Tests {
     public void TestCompilePackAssignment() {
       string name = "id";
       var program = AstHelper.Block(
-        AstHelper.Assign(AstHelper.Targets(AstHelper.Id(name)),
+        AstHelper.Assign(AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(name))),
                          AstHelper.NumberConstant(1),
                          AstHelper.NumberConstant(2)),
         AstHelper.ExpressionStmt(AstHelper.Id(name))
@@ -103,8 +108,10 @@ namespace SeedLang.Interpreter.Tests {
       string a = "a";
       string b = "b";
       var program = AstHelper.Block(
-        AstHelper.Assign(AstHelper.Targets(AstHelper.Id(a), AstHelper.Id(b)),
-                         AstHelper.List(AstHelper.NumberConstant(1), AstHelper.NumberConstant(2))),
+        AstHelper.Assign(
+          AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(a), AstHelper.Id(b))),
+          AstHelper.List(AstHelper.NumberConstant(1), AstHelper.NumberConstant(2))
+        ),
         AstHelper.ExpressionStmt(AstHelper.Id(a)),
         AstHelper.ExpressionStmt(AstHelper.Id(b))
       );
@@ -391,16 +398,18 @@ namespace SeedLang.Interpreter.Tests {
       string sum = "sum";
       string i = "i";
       var program = AstHelper.Block(
-        AstHelper.Assign(AstHelper.Targets(AstHelper.Id(sum)), AstHelper.NumberConstant(0)),
-        AstHelper.Assign(AstHelper.Targets(AstHelper.Id(i)), AstHelper.NumberConstant(0)),
+        AstHelper.Assign(AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(sum))),
+                         AstHelper.NumberConstant(0)),
+        AstHelper.Assign(AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(i))),
+                         AstHelper.NumberConstant(0)),
         AstHelper.While(
           AstHelper.Comparison(AstHelper.Id(i), AstHelper.CompOps(ComparisonOperator.LessEqual),
                                AstHelper.NumberConstant(10)),
           AstHelper.Block(
-            AstHelper.Assign(AstHelper.Targets(AstHelper.Id(sum)),
+            AstHelper.Assign(AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(sum))),
                              AstHelper.Binary(AstHelper.Id(sum), BinaryOperator.Add,
                                               AstHelper.Id(i))),
-            AstHelper.Assign(AstHelper.Targets(AstHelper.Id(i)),
+            AstHelper.Assign(AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(i))),
                              AstHelper.Binary(AstHelper.Id(i), BinaryOperator.Add,
                                               AstHelper.NumberConstant(1)))
           )
@@ -516,13 +525,15 @@ namespace SeedLang.Interpreter.Tests {
     public void TestCompileSubscriptAssignment() {
       string a = "a";
       var program = AstHelper.Block(
-        AstHelper.Assign(AstHelper.Targets(AstHelper.Id(a)),
+        AstHelper.Assign(AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(a))),
                          AstHelper.List(AstHelper.NumberConstant(1),
                                         AstHelper.NumberConstant(2),
                                         AstHelper.NumberConstant(3))),
-        AstHelper.Assign(AstHelper.Targets(AstHelper.Subscript(AstHelper.Id(a),
-                                                               AstHelper.NumberConstant(1))),
-                         AstHelper.NumberConstant(5)),
+        AstHelper.Assign(
+          AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Subscript(AstHelper.Id(a),
+                                                     AstHelper.NumberConstant(1)))),
+          AstHelper.NumberConstant(5)
+        ),
         AstHelper.ExpressionStmt(AstHelper.Subscript(AstHelper.Id(a), AstHelper.NumberConstant(1)))
       );
       string expected = (
@@ -547,14 +558,15 @@ namespace SeedLang.Interpreter.Tests {
     public void TestCompileMultipleSubscriptAssignment() {
       string a = "a";
       var program = AstHelper.Block(
-        AstHelper.Assign(AstHelper.Targets(AstHelper.Id(a)),
+        AstHelper.Assign(AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(a))),
                          AstHelper.List(AstHelper.NumberConstant(1),
                                         AstHelper.NumberConstant(2),
                                         AstHelper.NumberConstant(3))),
-        AstHelper.Assign(AstHelper.Targets(
+        AstHelper.Assign(
+          AstHelper.ChainedTargets(AstHelper.Targets(
             AstHelper.Subscript(AstHelper.Id(a), AstHelper.NumberConstant(0)),
             AstHelper.Subscript(AstHelper.Id(a), AstHelper.NumberConstant(1))
-          ),
+          )),
           AstHelper.Subscript(AstHelper.Id(a), AstHelper.NumberConstant(1)),
           AstHelper.Subscript(AstHelper.Id(a), AstHelper.NumberConstant(0))
         )

--- a/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
@@ -149,13 +149,15 @@ namespace SeedLang.Interpreter.Tests {
     public void TestSubscriptAssignment() {
       string a = "a";
       var program = AstHelper.Block(
-        AstHelper.Assign(AstHelper.Targets(AstHelper.Id(a)),
+        AstHelper.Assign(AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(a))),
                          AstHelper.List(AstHelper.NumberConstant(1),
                                         AstHelper.NumberConstant(2),
                                         AstHelper.NumberConstant(3))),
-        AstHelper.Assign(AstHelper.Targets(AstHelper.Subscript(AstHelper.Id(a),
-                                                               AstHelper.NumberConstant(1))),
-                         AstHelper.NumberConstant(5)),
+        AstHelper.Assign(
+          AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Subscript(AstHelper.Id(a),
+                                                     AstHelper.NumberConstant(1)))),
+          AstHelper.NumberConstant(5)
+        ),
         AstHelper.ExpressionStmt(AstHelper.Subscript(AstHelper.Id(a), AstHelper.NumberConstant(1)))
       );
       (string output, VisualizerHelper vh) = Run(program,
@@ -192,7 +194,8 @@ namespace SeedLang.Interpreter.Tests {
     public void TestAssignment() {
       string name = "name";
       var program = AstHelper.Block(
-        AstHelper.Assign(AstHelper.Targets(AstHelper.Id(name)), AstHelper.NumberConstant(1)),
+        AstHelper.Assign(AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(name))),
+                         AstHelper.NumberConstant(1)),
         AstHelper.ExpressionStmt(AstHelper.Id(name))
       );
       (string output, VisualizerHelper vh) = Run(program, new Type[] { typeof(Event.Assignment) });
@@ -206,9 +209,11 @@ namespace SeedLang.Interpreter.Tests {
       string a = "a";
       string b = "b";
       var block = AstHelper.Block(
-        AstHelper.Assign(AstHelper.Targets(AstHelper.Id(a), AstHelper.Id(b)),
-                         AstHelper.NumberConstant(1),
-                         AstHelper.NumberConstant(2)),
+        AstHelper.Assign(
+          AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(a), AstHelper.Id(b))),
+          AstHelper.NumberConstant(1),
+          AstHelper.NumberConstant(2)
+        ),
         AstHelper.ExpressionStmt(AstHelper.Id(a)),
         AstHelper.ExpressionStmt(AstHelper.Id(b))
       );
@@ -229,7 +234,7 @@ namespace SeedLang.Interpreter.Tests {
     public void TestPackAssignment() {
       string name = "id";
       var block = AstHelper.Block(
-        AstHelper.Assign(AstHelper.Targets(AstHelper.Id(name)),
+        AstHelper.Assign(AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(name))),
                          AstHelper.NumberConstant(1),
                          AstHelper.NumberConstant(2)),
         AstHelper.ExpressionStmt(AstHelper.Id(name))
@@ -245,8 +250,10 @@ namespace SeedLang.Interpreter.Tests {
       string a = "a";
       string b = "b";
       var block = AstHelper.Block(
-        AstHelper.Assign(AstHelper.Targets(AstHelper.Id(a), AstHelper.Id(b)),
-                         AstHelper.List(AstHelper.NumberConstant(1), AstHelper.NumberConstant(2))),
+        AstHelper.Assign(
+          AstHelper.ChainedTargets(AstHelper.Targets(AstHelper.Id(a), AstHelper.Id(b))),
+          AstHelper.List(AstHelper.NumberConstant(1), AstHelper.NumberConstant(2))
+        ),
         AstHelper.ExpressionStmt(AstHelper.Id(a)),
         AstHelper.ExpressionStmt(AstHelper.Id(b))
       );

--- a/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
@@ -266,6 +266,18 @@ namespace SeedLang.Interpreter.Tests {
     }
 
     [Fact]
+    public void TestChainedAssignment() {
+      string source = @"
+a = a[1] = [1, 2, 3]
+x, y = z = 1, 2
+print(a, x, y, z)
+";
+      (string output, VisualizerHelper _) = Run(Parse(source), Array.Empty<Type>());
+      var expectedOutput = $"[1, [...], 3] 1 2 (1, 2)" + Environment.NewLine;
+      Assert.Equal(expectedOutput, output);
+    }
+
+    [Fact]
     public void TestSingleStepNotification() {
       string source = @"
 # [[ Assign(a) ]]

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonContainerTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonContainerTests.cs
@@ -266,7 +266,7 @@ namespace SeedLang.X.Tests {
       string expected = "[Ln 1, Col 0 - Ln 1, Col 7] AssignmentStatement\n" +
                         "  [Ln 1, Col 0 - Ln 1, Col 3] SubscriptExpression\n" +
                         "    [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (a)\n" +
-                        "    [Ln 1, Col 2 - Ln 1, Col 2] NumberConstantExpression (0)\n" +
+                        "    [Ln 1, Col 2 - Ln 1, Col 2] NumberConstantExpression (0) =\n" +
                         "  [Ln 1, Col 7 - Ln 1, Col 7] NumberConstantExpression (1)";
       string expectedTokens = "Variable [Ln 1, Col 0 - Ln 1, Col 0]," +
                               "OpenBracket [Ln 1, Col 1 - Ln 1, Col 1]," +

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonExpressionTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonExpressionTests.cs
@@ -62,7 +62,7 @@ namespace SeedLang.X.Tests {
     [InlineData("id = 1",
 
                 "[Ln 1, Col 0 - Ln 1, Col 5] AssignmentStatement\n" +
-                "  [Ln 1, Col 0 - Ln 1, Col 1] IdentifierExpression (id)\n" +
+                "  [Ln 1, Col 0 - Ln 1, Col 1] IdentifierExpression (id) =\n" +
                 "  [Ln 1, Col 5 - Ln 1, Col 5] NumberConstantExpression (1)",
 
                 "Variable [Ln 1, Col 0 - Ln 1, Col 1]," +

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonStatementTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonStatementTests.cs
@@ -14,6 +14,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
 using SeedLang.Ast;
 using SeedLang.Common;
 using Xunit;
@@ -22,115 +24,187 @@ namespace SeedLang.X.Tests {
   public class SeedPythonStatementTests {
     [Fact]
     public void TestOneLineComments() {
-      string source = "# comment\n";
-      string expected = "[Ln 1, Col 9 - Ln 1, Col 9] BlockStatement";
-      string expectedTokens = "";
-      TestPythonParser(source, expected, expectedTokens);
+      string source = "# comment";
+      var expectedAst = new string[] { "[Ln 1, Col 9 - Ln 1, Col 9] BlockStatement" };
+      var expectedTokens = Array.Empty<string>();
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestComments() {
-      string source = "# comment\nprint(1)";
-      string expected = "[Ln 2, Col 0 - Ln 2, Col 7] ExpressionStatement\n" +
-                        "  [Ln 2, Col 0 - Ln 2, Col 7] CallExpression\n" +
-                        "    [Ln 2, Col 0 - Ln 2, Col 4] IdentifierExpression (print)\n" +
-                        "    [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)";
-      string expectedTokens = "Variable [Ln 2, Col 0 - Ln 2, Col 4]," +
-                              "OpenParenthesis [Ln 2, Col 5 - Ln 2, Col 5]," +
-                              "Number [Ln 2, Col 6 - Ln 2, Col 6]," +
-                              "CloseParenthesis [Ln 2, Col 7 - Ln 2, Col 7]";
-      TestPythonParser(source, expected, expectedTokens);
+      string source = "# comment\n" +
+                      "print(1)";
+      var expectedAst = new string[] {
+        "[Ln 2, Col 0 - Ln 2, Col 7] ExpressionStatement",
+        "  [Ln 2, Col 0 - Ln 2, Col 7] CallExpression",
+        "    [Ln 2, Col 0 - Ln 2, Col 4] IdentifierExpression (print)",
+        "    [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)",
+      };
+      var expectedTokens = new string[] {
+        "Variable [Ln 2, Col 0 - Ln 2, Col 4]",
+        "OpenParenthesis [Ln 2, Col 5 - Ln 2, Col 5]",
+        "Number [Ln 2, Col 6 - Ln 2, Col 6]",
+        "CloseParenthesis [Ln 2, Col 7 - Ln 2, Col 7]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestAssignment() {
       string source = "x = 1";
-      string expected = "[Ln 1, Col 0 - Ln 1, Col 4] AssignmentStatement\n" +
-                        "  [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x)\n" +
-                        "  [Ln 1, Col 4 - Ln 1, Col 4] NumberConstantExpression (1)";
-      string expectedTokens = "Variable [Ln 1, Col 0 - Ln 1, Col 0]," +
-                              "Operator [Ln 1, Col 2 - Ln 1, Col 2]," +
-                              "Number [Ln 1, Col 4 - Ln 1, Col 4]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] {
+        "[Ln 1, Col 0 - Ln 1, Col 4] AssignmentStatement",
+        "  [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x) =",
+        "  [Ln 1, Col 4 - Ln 1, Col 4] NumberConstantExpression (1)",
+      };
+      var expectedTokens = new string[] {
+        "Variable [Ln 1, Col 0 - Ln 1, Col 0]",
+        "Operator [Ln 1, Col 2 - Ln 1, Col 2]",
+        "Number [Ln 1, Col 4 - Ln 1, Col 4]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestMultipleAssignment() {
       string source = "x, y = 1, 2";
-      string expected = "[Ln 1, Col 0 - Ln 1, Col 10] AssignmentStatement\n" +
-                        "  [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x)\n" +
-                        "  [Ln 1, Col 3 - Ln 1, Col 3] IdentifierExpression (y)\n" +
-                        "  [Ln 1, Col 7 - Ln 1, Col 7] NumberConstantExpression (1)\n" +
-                        "  [Ln 1, Col 10 - Ln 1, Col 10] NumberConstantExpression (2)";
-      string expectedTokens = "Variable [Ln 1, Col 0 - Ln 1, Col 0]," +
-                              "Symbol [Ln 1, Col 1 - Ln 1, Col 1]," +
-                              "Variable [Ln 1, Col 3 - Ln 1, Col 3]," +
-                              "Operator [Ln 1, Col 5 - Ln 1, Col 5]," +
-                              "Number [Ln 1, Col 7 - Ln 1, Col 7]," +
-                              "Symbol [Ln 1, Col 8 - Ln 1, Col 8]," +
-                              "Number [Ln 1, Col 10 - Ln 1, Col 10]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] {
+        "[Ln 1, Col 0 - Ln 1, Col 10] AssignmentStatement",
+        "  [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x)",
+        "  [Ln 1, Col 3 - Ln 1, Col 3] IdentifierExpression (y) =",
+        "  [Ln 1, Col 7 - Ln 1, Col 7] NumberConstantExpression (1)",
+        "  [Ln 1, Col 10 - Ln 1, Col 10] NumberConstantExpression (2)",
+      };
+      var expectedTokens = new string[] {
+        "Variable [Ln 1, Col 0 - Ln 1, Col 0]",
+        "Symbol [Ln 1, Col 1 - Ln 1, Col 1]",
+        "Variable [Ln 1, Col 3 - Ln 1, Col 3]",
+        "Operator [Ln 1, Col 5 - Ln 1, Col 5]",
+        "Number [Ln 1, Col 7 - Ln 1, Col 7]",
+        "Symbol [Ln 1, Col 8 - Ln 1, Col 8]",
+        "Number [Ln 1, Col 10 - Ln 1, Col 10]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
+    }
+
+    [Fact]
+    public void TestChainedAssignment() {
+      string source = "x = y = 1";
+      var expectedAst = new string[] {
+        "[Ln 1, Col 0 - Ln 1, Col 8] AssignmentStatement",
+        "  [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x) =",
+        "  [Ln 1, Col 4 - Ln 1, Col 4] IdentifierExpression (y) =",
+        "  [Ln 1, Col 8 - Ln 1, Col 8] NumberConstantExpression (1)",
+      };
+      var expectedTokens = new string[] {
+        "Variable [Ln 1, Col 0 - Ln 1, Col 0]",
+        "Operator [Ln 1, Col 2 - Ln 1, Col 2]",
+        "Variable [Ln 1, Col 4 - Ln 1, Col 4]",
+        "Operator [Ln 1, Col 6 - Ln 1, Col 6]",
+        "Number [Ln 1, Col 8 - Ln 1, Col 8]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
+    }
+
+    [Fact]
+    public void TestChainedMultipleAssignment() {
+      string source = "a, b = x, y = 1, 2";
+      var expectedAst = new string[] {
+        "[Ln 1, Col 0 - Ln 1, Col 17] AssignmentStatement",
+        "  [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (a)",
+        "  [Ln 1, Col 3 - Ln 1, Col 3] IdentifierExpression (b) =",
+        "  [Ln 1, Col 7 - Ln 1, Col 7] IdentifierExpression (x)",
+        "  [Ln 1, Col 10 - Ln 1, Col 10] IdentifierExpression (y) =",
+        "  [Ln 1, Col 14 - Ln 1, Col 14] NumberConstantExpression (1)",
+        "  [Ln 1, Col 17 - Ln 1, Col 17] NumberConstantExpression (2)",
+      };
+      var expectedTokens = new string[] {
+        "Variable [Ln 1, Col 0 - Ln 1, Col 0]",
+        "Symbol [Ln 1, Col 1 - Ln 1, Col 1]",
+        "Variable [Ln 1, Col 3 - Ln 1, Col 3]",
+        "Operator [Ln 1, Col 5 - Ln 1, Col 5]",
+        "Variable [Ln 1, Col 7 - Ln 1, Col 7]",
+        "Symbol [Ln 1, Col 8 - Ln 1, Col 8]",
+        "Variable [Ln 1, Col 10 - Ln 1, Col 10]",
+        "Operator [Ln 1, Col 12 - Ln 1, Col 12]",
+        "Number [Ln 1, Col 14 - Ln 1, Col 14]",
+        "Symbol [Ln 1, Col 15 - Ln 1, Col 15]",
+        "Number [Ln 1, Col 17 - Ln 1, Col 17]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestAugmentedAssignment() {
       string source = "x += 1";
-      string expected = "[Ln 1, Col 0 - Ln 1, Col 5] AssignmentStatement\n" +
-                        "  [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x)\n" +
-                        "  [Ln 1, Col 0 - Ln 1, Col 5] BinaryExpression (+)\n" +
-                        "    [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x)\n" +
-                        "    [Ln 1, Col 5 - Ln 1, Col 5] NumberConstantExpression (1)";
-      string expectedTokens = "Variable [Ln 1, Col 0 - Ln 1, Col 0]," +
-                              "Operator [Ln 1, Col 2 - Ln 1, Col 3]," +
-                              "Number [Ln 1, Col 5 - Ln 1, Col 5]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 1, Col 5] AssignmentStatement",
+        "  [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x) =",
+        "  [Ln 1, Col 0 - Ln 1, Col 5] BinaryExpression (+)",
+        "    [Ln 1, Col 0 - Ln 1, Col 0] IdentifierExpression (x)",
+        "    [Ln 1, Col 5 - Ln 1, Col 5] NumberConstantExpression (1)",
+      };
+      var expectedTokens = new string[] {
+        "Variable [Ln 1, Col 0 - Ln 1, Col 0]",
+        "Operator [Ln 1, Col 2 - Ln 1, Col 3]",
+        "Number [Ln 1, Col 5 - Ln 1, Col 5]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestStringAssignment() {
       string source = "str = 'test string'";
-      string expected = "[Ln 1, Col 0 - Ln 1, Col 18] AssignmentStatement\n" +
-                        "  [Ln 1, Col 0 - Ln 1, Col 2] IdentifierExpression (str)\n" +
-                        "  [Ln 1, Col 6 - Ln 1, Col 18] StringConstantExpression (test string)";
-      string expectedTokens = "Variable [Ln 1, Col 0 - Ln 1, Col 2]," +
-                              "Operator [Ln 1, Col 4 - Ln 1, Col 4]," +
-                              "String [Ln 1, Col 6 - Ln 1, Col 18]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 1, Col 18] AssignmentStatement",
+        "  [Ln 1, Col 0 - Ln 1, Col 2] IdentifierExpression (str) =",
+        "  [Ln 1, Col 6 - Ln 1, Col 18] StringConstantExpression (test string)",
+      };
+      var expectedTokens = new string[] {
+        "Variable [Ln 1, Col 0 - Ln 1, Col 2]",
+        "Operator [Ln 1, Col 4 - Ln 1, Col 4]",
+        "String [Ln 1, Col 6 - Ln 1, Col 18]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestMultipleStringAssignment() {
       string source = "str = 'a' \"b\" 'c'";
-      string expected = "[Ln 1, Col 0 - Ln 1, Col 16] AssignmentStatement\n" +
-                        "  [Ln 1, Col 0 - Ln 1, Col 2] IdentifierExpression (str)\n" +
-                        "  [Ln 1, Col 6 - Ln 1, Col 16] StringConstantExpression (abc)";
-      string expectedTokens = "Variable [Ln 1, Col 0 - Ln 1, Col 2]," +
-                              "Operator [Ln 1, Col 4 - Ln 1, Col 4]," +
-                              "String [Ln 1, Col 6 - Ln 1, Col 8]," +
-                              "String [Ln 1, Col 10 - Ln 1, Col 12]," +
-                              "String [Ln 1, Col 14 - Ln 1, Col 16]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 1, Col 16] AssignmentStatement",
+        "  [Ln 1, Col 0 - Ln 1, Col 2] IdentifierExpression (str) =",
+        "  [Ln 1, Col 6 - Ln 1, Col 16] StringConstantExpression (abc)",
+      };
+      var expectedTokens = new string[] {
+        "Variable [Ln 1, Col 0 - Ln 1, Col 2]",
+        "Operator [Ln 1, Col 4 - Ln 1, Col 4]",
+        "String [Ln 1, Col 6 - Ln 1, Col 8]",
+        "String [Ln 1, Col 10 - Ln 1, Col 12]",
+        "String [Ln 1, Col 14 - Ln 1, Col 16]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestIf() {
       string source = "if 1 < 2: x = 1";
-      string expected = "[Ln 1, Col 0 - Ln 1, Col 14] IfStatement\n" +
-                        "  [Ln 1, Col 3 - Ln 1, Col 7] ComparisonExpression\n" +
-                        "    [Ln 1, Col 3 - Ln 1, Col 3] NumberConstantExpression (1) (<)\n" +
-                        "    [Ln 1, Col 7 - Ln 1, Col 7] NumberConstantExpression (2)\n" +
-                        "  [Ln 1, Col 10 - Ln 1, Col 14] AssignmentStatement\n" +
-                        "    [Ln 1, Col 10 - Ln 1, Col 10] IdentifierExpression (x)\n" +
-                        "    [Ln 1, Col 14 - Ln 1, Col 14] NumberConstantExpression (1)";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 1]," +
-                              "Number [Ln 1, Col 3 - Ln 1, Col 3]," +
-                              "Operator [Ln 1, Col 5 - Ln 1, Col 5]," +
-                              "Number [Ln 1, Col 7 - Ln 1, Col 7]," +
-                              "Symbol [Ln 1, Col 8 - Ln 1, Col 8]," +
-                              "Variable [Ln 1, Col 10 - Ln 1, Col 10]," +
-                              "Operator [Ln 1, Col 12 - Ln 1, Col 12]," +
-                              "Number [Ln 1, Col 14 - Ln 1, Col 14]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 1, Col 14] IfStatement",
+        "  [Ln 1, Col 3 - Ln 1, Col 7] ComparisonExpression",
+        "    [Ln 1, Col 3 - Ln 1, Col 3] NumberConstantExpression (1) (<)",
+        "    [Ln 1, Col 7 - Ln 1, Col 7] NumberConstantExpression (2)",
+        "  [Ln 1, Col 10 - Ln 1, Col 14] AssignmentStatement",
+        "    [Ln 1, Col 10 - Ln 1, Col 10] IdentifierExpression (x) =",
+        "    [Ln 1, Col 14 - Ln 1, Col 14] NumberConstantExpression (1)",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 1]",
+        "Number [Ln 1, Col 3 - Ln 1, Col 3]",
+        "Operator [Ln 1, Col 5 - Ln 1, Col 5]",
+        "Number [Ln 1, Col 7 - Ln 1, Col 7]",
+        "Symbol [Ln 1, Col 8 - Ln 1, Col 8]",
+        "Variable [Ln 1, Col 10 - Ln 1, Col 10]",
+        "Operator [Ln 1, Col 12 - Ln 1, Col 12]",
+        "Number [Ln 1, Col 14 - Ln 1, Col 14]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
@@ -139,26 +213,29 @@ namespace SeedLang.X.Tests {
                       "  x = 1\n" +
                       "else:\n" +
                       "  x = 2";
-      string expected = "[Ln 1, Col 0 - Ln 4, Col 6] IfStatement\n" +
-                        "  [Ln 1, Col 3 - Ln 1, Col 6] BooleanConstantExpression (True)\n" +
-                        "  [Ln 2, Col 2 - Ln 2, Col 6] AssignmentStatement\n" +
-                        "    [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (x)\n" +
-                        "    [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)\n" +
-                        "  [Ln 4, Col 2 - Ln 4, Col 6] AssignmentStatement\n" +
-                        "    [Ln 4, Col 2 - Ln 4, Col 2] IdentifierExpression (x)\n" +
-                        "    [Ln 4, Col 6 - Ln 4, Col 6] NumberConstantExpression (2)";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 1]," +
-                              "Boolean [Ln 1, Col 3 - Ln 1, Col 6]," +
-                              "Symbol [Ln 1, Col 7 - Ln 1, Col 7]," +
-                              "Variable [Ln 2, Col 2 - Ln 2, Col 2]," +
-                              "Operator [Ln 2, Col 4 - Ln 2, Col 4]," +
-                              "Number [Ln 2, Col 6 - Ln 2, Col 6]," +
-                              "Keyword [Ln 3, Col 0 - Ln 3, Col 3]," +
-                              "Symbol [Ln 3, Col 4 - Ln 3, Col 4]," +
-                              "Variable [Ln 4, Col 2 - Ln 4, Col 2]," +
-                              "Operator [Ln 4, Col 4 - Ln 4, Col 4]," +
-                              "Number [Ln 4, Col 6 - Ln 4, Col 6]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 4, Col 6] IfStatement",
+        "  [Ln 1, Col 3 - Ln 1, Col 6] BooleanConstantExpression (True)",
+        "  [Ln 2, Col 2 - Ln 2, Col 6] AssignmentStatement",
+        "    [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (x) =",
+        "    [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)",
+        "  [Ln 4, Col 2 - Ln 4, Col 6] AssignmentStatement",
+        "    [Ln 4, Col 2 - Ln 4, Col 2] IdentifierExpression (x) =",
+        "    [Ln 4, Col 6 - Ln 4, Col 6] NumberConstantExpression (2)",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 1]",
+        "Boolean [Ln 1, Col 3 - Ln 1, Col 6]",
+        "Symbol [Ln 1, Col 7 - Ln 1, Col 7]",
+        "Variable [Ln 2, Col 2 - Ln 2, Col 2]",
+        "Operator [Ln 2, Col 4 - Ln 2, Col 4]",
+        "Number [Ln 2, Col 6 - Ln 2, Col 6]",
+        "Keyword [Ln 3, Col 0 - Ln 3, Col 3]",
+        "Symbol [Ln 3, Col 4 - Ln 3, Col 4]",
+        "Variable [Ln 4, Col 2 - Ln 4, Col 2]",
+        "Operator [Ln 4, Col 4 - Ln 4, Col 4]",
+        "Number [Ln 4, Col 6 - Ln 4, Col 6]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
@@ -166,19 +243,22 @@ namespace SeedLang.X.Tests {
       string source = "if True:\n" +
                       "  pass\n" +
                       "else:\n" +
-                      "  pass";
-      string expected = "[Ln 1, Col 0 - Ln 4, Col 5] IfStatement\n" +
-                        "  [Ln 1, Col 3 - Ln 1, Col 6] BooleanConstantExpression (True)\n" +
-                        "  [Ln 2, Col 2 - Ln 2, Col 5] PassStatement\n" +
-                        "  [Ln 4, Col 2 - Ln 4, Col 5] PassStatement";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 1]," +
-                              "Boolean [Ln 1, Col 3 - Ln 1, Col 6]," +
-                              "Symbol [Ln 1, Col 7 - Ln 1, Col 7]," +
-                              "Keyword [Ln 2, Col 2 - Ln 2, Col 5]," +
-                              "Keyword [Ln 3, Col 0 - Ln 3, Col 3]," +
-                              "Symbol [Ln 3, Col 4 - Ln 3, Col 4]," +
-                              "Keyword [Ln 4, Col 2 - Ln 4, Col 5]";
-      TestPythonParser(source, expected, expectedTokens);
+                      "  pass\n";
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 4, Col 5] IfStatement",
+        "  [Ln 1, Col 3 - Ln 1, Col 6] BooleanConstantExpression (True)",
+        "  [Ln 2, Col 2 - Ln 2, Col 5] PassStatement",
+        "  [Ln 4, Col 2 - Ln 4, Col 5] PassStatement",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 1]",
+        "Boolean [Ln 1, Col 3 - Ln 1, Col 6]",
+        "Symbol [Ln 1, Col 7 - Ln 1, Col 7]",
+        "Keyword [Ln 2, Col 2 - Ln 2, Col 5]",
+        "Keyword [Ln 3, Col 0 - Ln 3, Col 3]",
+        "Symbol [Ln 3, Col 4 - Ln 3, Col 4]",
+        "Keyword [Ln 4, Col 2 - Ln 4, Col 5]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
@@ -191,123 +271,135 @@ namespace SeedLang.X.Tests {
                       "  x = 3\n" +
                       "else:\n" +
                       "  x = 4";
-      string expected = "[Ln 1, Col 0 - Ln 8, Col 6] IfStatement\n" +
-                        "  [Ln 1, Col 3 - Ln 1, Col 6] BooleanConstantExpression (True)\n" +
-                        "  [Ln 2, Col 2 - Ln 2, Col 6] AssignmentStatement\n" +
-                        "    [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (x)\n" +
-                        "    [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)\n" +
-                        "  [Ln 3, Col 0 - Ln 8, Col 6] IfStatement\n" +
-                        "    [Ln 3, Col 5 - Ln 3, Col 9] BooleanConstantExpression (False)\n" +
-                        "    [Ln 4, Col 2 - Ln 4, Col 6] AssignmentStatement\n" +
-                        "      [Ln 4, Col 2 - Ln 4, Col 2] IdentifierExpression (x)\n" +
-                        "      [Ln 4, Col 6 - Ln 4, Col 6] NumberConstantExpression (2)\n" +
-                        "    [Ln 5, Col 0 - Ln 8, Col 6] IfStatement\n" +
-                        "      [Ln 5, Col 5 - Ln 5, Col 9] ComparisonExpression\n" +
-                        "        [Ln 5, Col 5 - Ln 5, Col 5] NumberConstantExpression (1) (<)\n" +
-                        "        [Ln 5, Col 9 - Ln 5, Col 9] NumberConstantExpression (2)\n" +
-                        "      [Ln 6, Col 2 - Ln 6, Col 6] AssignmentStatement\n" +
-                        "        [Ln 6, Col 2 - Ln 6, Col 2] IdentifierExpression (x)\n" +
-                        "        [Ln 6, Col 6 - Ln 6, Col 6] NumberConstantExpression (3)\n" +
-                        "      [Ln 8, Col 2 - Ln 8, Col 6] AssignmentStatement\n" +
-                        "        [Ln 8, Col 2 - Ln 8, Col 2] IdentifierExpression (x)\n" +
-                        "        [Ln 8, Col 6 - Ln 8, Col 6] NumberConstantExpression (4)";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 1]," +
-                              "Boolean [Ln 1, Col 3 - Ln 1, Col 6]," +
-                              "Symbol [Ln 1, Col 7 - Ln 1, Col 7]," +
-                              "Variable [Ln 2, Col 2 - Ln 2, Col 2]," +
-                              "Operator [Ln 2, Col 4 - Ln 2, Col 4]," +
-                              "Number [Ln 2, Col 6 - Ln 2, Col 6]," +
-                              "Keyword [Ln 3, Col 0 - Ln 3, Col 3]," +
-                              "Boolean [Ln 3, Col 5 - Ln 3, Col 9]," +
-                              "Symbol [Ln 3, Col 10 - Ln 3, Col 10]," +
-                              "Variable [Ln 4, Col 2 - Ln 4, Col 2]," +
-                              "Operator [Ln 4, Col 4 - Ln 4, Col 4]," +
-                              "Number [Ln 4, Col 6 - Ln 4, Col 6]," +
-                              "Keyword [Ln 5, Col 0 - Ln 5, Col 3]," +
-                              "Number [Ln 5, Col 5 - Ln 5, Col 5]," +
-                              "Operator [Ln 5, Col 7 - Ln 5, Col 7]," +
-                              "Number [Ln 5, Col 9 - Ln 5, Col 9]," +
-                              "Symbol [Ln 5, Col 10 - Ln 5, Col 10]," +
-                              "Variable [Ln 6, Col 2 - Ln 6, Col 2]," +
-                              "Operator [Ln 6, Col 4 - Ln 6, Col 4]," +
-                              "Number [Ln 6, Col 6 - Ln 6, Col 6]," +
-                              "Keyword [Ln 7, Col 0 - Ln 7, Col 3]," +
-                              "Symbol [Ln 7, Col 4 - Ln 7, Col 4]," +
-                              "Variable [Ln 8, Col 2 - Ln 8, Col 2]," +
-                              "Operator [Ln 8, Col 4 - Ln 8, Col 4]," +
-                              "Number [Ln 8, Col 6 - Ln 8, Col 6]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 8, Col 6] IfStatement",
+        "  [Ln 1, Col 3 - Ln 1, Col 6] BooleanConstantExpression (True)",
+        "  [Ln 2, Col 2 - Ln 2, Col 6] AssignmentStatement",
+        "    [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (x) =",
+        "    [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)",
+        "  [Ln 3, Col 0 - Ln 8, Col 6] IfStatement",
+        "    [Ln 3, Col 5 - Ln 3, Col 9] BooleanConstantExpression (False)",
+        "    [Ln 4, Col 2 - Ln 4, Col 6] AssignmentStatement",
+        "      [Ln 4, Col 2 - Ln 4, Col 2] IdentifierExpression (x) =",
+        "      [Ln 4, Col 6 - Ln 4, Col 6] NumberConstantExpression (2)",
+        "    [Ln 5, Col 0 - Ln 8, Col 6] IfStatement",
+        "      [Ln 5, Col 5 - Ln 5, Col 9] ComparisonExpression",
+        "        [Ln 5, Col 5 - Ln 5, Col 5] NumberConstantExpression (1) (<)",
+        "        [Ln 5, Col 9 - Ln 5, Col 9] NumberConstantExpression (2)",
+        "      [Ln 6, Col 2 - Ln 6, Col 6] AssignmentStatement",
+        "        [Ln 6, Col 2 - Ln 6, Col 2] IdentifierExpression (x) =",
+        "        [Ln 6, Col 6 - Ln 6, Col 6] NumberConstantExpression (3)",
+        "      [Ln 8, Col 2 - Ln 8, Col 6] AssignmentStatement",
+        "        [Ln 8, Col 2 - Ln 8, Col 2] IdentifierExpression (x) =",
+        "        [Ln 8, Col 6 - Ln 8, Col 6] NumberConstantExpression (4)",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 1]",
+        "Boolean [Ln 1, Col 3 - Ln 1, Col 6]",
+        "Symbol [Ln 1, Col 7 - Ln 1, Col 7]",
+        "Variable [Ln 2, Col 2 - Ln 2, Col 2]",
+        "Operator [Ln 2, Col 4 - Ln 2, Col 4]",
+        "Number [Ln 2, Col 6 - Ln 2, Col 6]",
+        "Keyword [Ln 3, Col 0 - Ln 3, Col 3]",
+        "Boolean [Ln 3, Col 5 - Ln 3, Col 9]",
+        "Symbol [Ln 3, Col 10 - Ln 3, Col 10]",
+        "Variable [Ln 4, Col 2 - Ln 4, Col 2]",
+        "Operator [Ln 4, Col 4 - Ln 4, Col 4]",
+        "Number [Ln 4, Col 6 - Ln 4, Col 6]",
+        "Keyword [Ln 5, Col 0 - Ln 5, Col 3]",
+        "Number [Ln 5, Col 5 - Ln 5, Col 5]",
+        "Operator [Ln 5, Col 7 - Ln 5, Col 7]",
+        "Number [Ln 5, Col 9 - Ln 5, Col 9]",
+        "Symbol [Ln 5, Col 10 - Ln 5, Col 10]",
+        "Variable [Ln 6, Col 2 - Ln 6, Col 2]",
+        "Operator [Ln 6, Col 4 - Ln 6, Col 4]",
+        "Number [Ln 6, Col 6 - Ln 6, Col 6]",
+        "Keyword [Ln 7, Col 0 - Ln 7, Col 3]",
+        "Symbol [Ln 7, Col 4 - Ln 7, Col 4]",
+        "Variable [Ln 8, Col 2 - Ln 8, Col 2]",
+        "Operator [Ln 8, Col 4 - Ln 8, Col 4]",
+        "Number [Ln 8, Col 6 - Ln 8, Col 6]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestForInList() {
       string source = "for n in [1, 2, 3]: n";
-      string expected = "[Ln 1, Col 0 - Ln 1, Col 20] ForInStatement\n" +
-                        "  [Ln 1, Col 4 - Ln 1, Col 4] IdentifierExpression (n)\n" +
-                        "  [Ln 1, Col 9 - Ln 1, Col 17] ListExpression\n" +
-                        "    [Ln 1, Col 10 - Ln 1, Col 10] NumberConstantExpression (1)\n" +
-                        "    [Ln 1, Col 13 - Ln 1, Col 13] NumberConstantExpression (2)\n" +
-                        "    [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (3)\n" +
-                        "  [Ln 1, Col 20 - Ln 1, Col 20] ExpressionStatement\n" +
-                        "    [Ln 1, Col 20 - Ln 1, Col 20] IdentifierExpression (n)";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                              "Variable [Ln 1, Col 4 - Ln 1, Col 4]," +
-                              "Keyword [Ln 1, Col 6 - Ln 1, Col 7]," +
-                              "OpenBracket [Ln 1, Col 9 - Ln 1, Col 9]," +
-                              "Number [Ln 1, Col 10 - Ln 1, Col 10]," +
-                              "Symbol [Ln 1, Col 11 - Ln 1, Col 11]," +
-                              "Number [Ln 1, Col 13 - Ln 1, Col 13]," +
-                              "Symbol [Ln 1, Col 14 - Ln 1, Col 14]," +
-                              "Number [Ln 1, Col 16 - Ln 1, Col 16]," +
-                              "CloseBracket [Ln 1, Col 17 - Ln 1, Col 17]," +
-                              "Symbol [Ln 1, Col 18 - Ln 1, Col 18]," +
-                              "Variable [Ln 1, Col 20 - Ln 1, Col 20]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 1, Col 20] ForInStatement",
+        "  [Ln 1, Col 4 - Ln 1, Col 4] IdentifierExpression (n)",
+        "  [Ln 1, Col 9 - Ln 1, Col 17] ListExpression",
+        "    [Ln 1, Col 10 - Ln 1, Col 10] NumberConstantExpression (1)",
+        "    [Ln 1, Col 13 - Ln 1, Col 13] NumberConstantExpression (2)",
+        "    [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (3)",
+        "  [Ln 1, Col 20 - Ln 1, Col 20] ExpressionStatement",
+        "    [Ln 1, Col 20 - Ln 1, Col 20] IdentifierExpression (n)",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 2]",
+        "Variable [Ln 1, Col 4 - Ln 1, Col 4]",
+        "Keyword [Ln 1, Col 6 - Ln 1, Col 7]",
+        "OpenBracket [Ln 1, Col 9 - Ln 1, Col 9]",
+        "Number [Ln 1, Col 10 - Ln 1, Col 10]",
+        "Symbol [Ln 1, Col 11 - Ln 1, Col 11]",
+        "Number [Ln 1, Col 13 - Ln 1, Col 13]",
+        "Symbol [Ln 1, Col 14 - Ln 1, Col 14]",
+        "Number [Ln 1, Col 16 - Ln 1, Col 16]",
+        "CloseBracket [Ln 1, Col 17 - Ln 1, Col 17]",
+        "Symbol [Ln 1, Col 18 - Ln 1, Col 18]",
+        "Variable [Ln 1, Col 20 - Ln 1, Col 20]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestForInRange() {
       string source = "for n in range(2, 10, 3): n";
-      string expected = "[Ln 1, Col 0 - Ln 1, Col 26] ForInStatement\n" +
-                        "  [Ln 1, Col 4 - Ln 1, Col 4] IdentifierExpression (n)\n" +
-                        "  [Ln 1, Col 9 - Ln 1, Col 23] CallExpression\n" +
-                        "    [Ln 1, Col 9 - Ln 1, Col 13] IdentifierExpression (range)\n" +
-                        "    [Ln 1, Col 15 - Ln 1, Col 15] NumberConstantExpression (2)\n" +
-                        "    [Ln 1, Col 18 - Ln 1, Col 19] NumberConstantExpression (10)\n" +
-                        "    [Ln 1, Col 22 - Ln 1, Col 22] NumberConstantExpression (3)\n" +
-                        "  [Ln 1, Col 26 - Ln 1, Col 26] ExpressionStatement\n" +
-                        "    [Ln 1, Col 26 - Ln 1, Col 26] IdentifierExpression (n)";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                              "Variable [Ln 1, Col 4 - Ln 1, Col 4]," +
-                              "Keyword [Ln 1, Col 6 - Ln 1, Col 7]," +
-                              "Variable [Ln 1, Col 9 - Ln 1, Col 13]," +
-                              "OpenParenthesis [Ln 1, Col 14 - Ln 1, Col 14]," +
-                              "Number [Ln 1, Col 15 - Ln 1, Col 15]," +
-                              "Symbol [Ln 1, Col 16 - Ln 1, Col 16]," +
-                              "Number [Ln 1, Col 18 - Ln 1, Col 19]," +
-                              "Symbol [Ln 1, Col 20 - Ln 1, Col 20]," +
-                              "Number [Ln 1, Col 22 - Ln 1, Col 22]," +
-                              "CloseParenthesis [Ln 1, Col 23 - Ln 1, Col 23]," +
-                              "Symbol [Ln 1, Col 24 - Ln 1, Col 24]," +
-                              "Variable [Ln 1, Col 26 - Ln 1, Col 26]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 1, Col 26] ForInStatement",
+        "  [Ln 1, Col 4 - Ln 1, Col 4] IdentifierExpression (n)",
+        "  [Ln 1, Col 9 - Ln 1, Col 23] CallExpression",
+        "    [Ln 1, Col 9 - Ln 1, Col 13] IdentifierExpression (range)",
+        "    [Ln 1, Col 15 - Ln 1, Col 15] NumberConstantExpression (2)",
+        "    [Ln 1, Col 18 - Ln 1, Col 19] NumberConstantExpression (10)",
+        "    [Ln 1, Col 22 - Ln 1, Col 22] NumberConstantExpression (3)",
+        "  [Ln 1, Col 26 - Ln 1, Col 26] ExpressionStatement",
+        "    [Ln 1, Col 26 - Ln 1, Col 26] IdentifierExpression (n)",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 2]",
+        "Variable [Ln 1, Col 4 - Ln 1, Col 4]",
+        "Keyword [Ln 1, Col 6 - Ln 1, Col 7]",
+        "Variable [Ln 1, Col 9 - Ln 1, Col 13]",
+        "OpenParenthesis [Ln 1, Col 14 - Ln 1, Col 14]",
+        "Number [Ln 1, Col 15 - Ln 1, Col 15]",
+        "Symbol [Ln 1, Col 16 - Ln 1, Col 16]",
+        "Number [Ln 1, Col 18 - Ln 1, Col 19]",
+        "Symbol [Ln 1, Col 20 - Ln 1, Col 20]",
+        "Number [Ln 1, Col 22 - Ln 1, Col 22]",
+        "CloseParenthesis [Ln 1, Col 23 - Ln 1, Col 23]",
+        "Symbol [Ln 1, Col 24 - Ln 1, Col 24]",
+        "Variable [Ln 1, Col 26 - Ln 1, Col 26]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestWhile() {
       string source = "while True: x = 1";
-      string expected = "[Ln 1, Col 0 - Ln 1, Col 16] WhileStatement\n" +
-                        "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)\n" +
-                        "  [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement\n" +
-                        "    [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x)\n" +
-                        "    [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 4]," +
-                              "Boolean [Ln 1, Col 6 - Ln 1, Col 9]," +
-                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                              "Variable [Ln 1, Col 12 - Ln 1, Col 12]," +
-                              "Operator [Ln 1, Col 14 - Ln 1, Col 14]," +
-                              "Number [Ln 1, Col 16 - Ln 1, Col 16]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 1, Col 16] WhileStatement",
+        "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)",
+        "  [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement",
+        "    [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x) =",
+        "    [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 4]",
+        "Boolean [Ln 1, Col 6 - Ln 1, Col 9]",
+        "Symbol [Ln 1, Col 10 - Ln 1, Col 10]",
+        "Variable [Ln 1, Col 12 - Ln 1, Col 12]",
+        "Operator [Ln 1, Col 14 - Ln 1, Col 14]",
+        "Number [Ln 1, Col 16 - Ln 1, Col 16]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
@@ -315,131 +407,149 @@ namespace SeedLang.X.Tests {
       string source = "while True:\n" +
                       "  x = 1\n" +
                       "  y = 2";
-      string expected = "[Ln 1, Col 0 - Ln 3, Col 6] WhileStatement\n" +
-                        "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)\n" +
-                        "  [Ln 2, Col 2 - Ln 3, Col 6] BlockStatement\n" +
-                        "    [Ln 2, Col 2 - Ln 2, Col 6] AssignmentStatement\n" +
-                        "      [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (x)\n" +
-                        "      [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)\n" +
-                        "    [Ln 3, Col 2 - Ln 3, Col 6] AssignmentStatement\n" +
-                        "      [Ln 3, Col 2 - Ln 3, Col 2] IdentifierExpression (y)\n" +
-                        "      [Ln 3, Col 6 - Ln 3, Col 6] NumberConstantExpression (2)";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 4]," +
-                              "Boolean [Ln 1, Col 6 - Ln 1, Col 9]," +
-                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                              "Variable [Ln 2, Col 2 - Ln 2, Col 2]," +
-                              "Operator [Ln 2, Col 4 - Ln 2, Col 4]," +
-                              "Number [Ln 2, Col 6 - Ln 2, Col 6]," +
-                              "Variable [Ln 3, Col 2 - Ln 3, Col 2]," +
-                              "Operator [Ln 3, Col 4 - Ln 3, Col 4]," +
-                              "Number [Ln 3, Col 6 - Ln 3, Col 6]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 3, Col 6] WhileStatement",
+        "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)",
+        "  [Ln 2, Col 2 - Ln 3, Col 6] BlockStatement",
+        "    [Ln 2, Col 2 - Ln 2, Col 6] AssignmentStatement",
+        "      [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (x) =",
+        "      [Ln 2, Col 6 - Ln 2, Col 6] NumberConstantExpression (1)",
+        "    [Ln 3, Col 2 - Ln 3, Col 6] AssignmentStatement",
+        "      [Ln 3, Col 2 - Ln 3, Col 2] IdentifierExpression (y) =",
+        "      [Ln 3, Col 6 - Ln 3, Col 6] NumberConstantExpression (2)",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 4]",
+        "Boolean [Ln 1, Col 6 - Ln 1, Col 9]",
+        "Symbol [Ln 1, Col 10 - Ln 1, Col 10]",
+        "Variable [Ln 2, Col 2 - Ln 2, Col 2]",
+        "Operator [Ln 2, Col 4 - Ln 2, Col 4]",
+        "Number [Ln 2, Col 6 - Ln 2, Col 6]",
+        "Variable [Ln 3, Col 2 - Ln 3, Col 2]",
+        "Operator [Ln 3, Col 4 - Ln 3, Col 4]",
+        "Number [Ln 3, Col 6 - Ln 3, Col 6]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestWhileWithSimpleStatementsBody() {
       string source = "while True: x = 1; y = 2";
-      string expected = "[Ln 1, Col 0 - Ln 1, Col 23] WhileStatement\n" +
-                        "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)\n" +
-                        "  [Ln 1, Col 12 - Ln 1, Col 23] BlockStatement\n" +
-                        "    [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement\n" +
-                        "      [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x)\n" +
-                        "      [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)\n" +
-                        "    [Ln 1, Col 19 - Ln 1, Col 23] AssignmentStatement\n" +
-                        "      [Ln 1, Col 19 - Ln 1, Col 19] IdentifierExpression (y)\n" +
-                        "      [Ln 1, Col 23 - Ln 1, Col 23] NumberConstantExpression (2)";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 4]," +
-                              "Boolean [Ln 1, Col 6 - Ln 1, Col 9]," +
-                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                              "Variable [Ln 1, Col 12 - Ln 1, Col 12]," +
-                              "Operator [Ln 1, Col 14 - Ln 1, Col 14]," +
-                              "Number [Ln 1, Col 16 - Ln 1, Col 16]," +
-                              "Symbol [Ln 1, Col 17 - Ln 1, Col 17]," +
-                              "Variable [Ln 1, Col 19 - Ln 1, Col 19]," +
-                              "Operator [Ln 1, Col 21 - Ln 1, Col 21]," +
-                              "Number [Ln 1, Col 23 - Ln 1, Col 23]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 1, Col 23] WhileStatement",
+        "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)",
+        "  [Ln 1, Col 12 - Ln 1, Col 23] BlockStatement",
+        "    [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement",
+        "      [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x) =",
+        "      [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)",
+        "    [Ln 1, Col 19 - Ln 1, Col 23] AssignmentStatement",
+        "      [Ln 1, Col 19 - Ln 1, Col 19] IdentifierExpression (y) =",
+        "      [Ln 1, Col 23 - Ln 1, Col 23] NumberConstantExpression (2)",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 4]",
+        "Boolean [Ln 1, Col 6 - Ln 1, Col 9]",
+        "Symbol [Ln 1, Col 10 - Ln 1, Col 10]",
+        "Variable [Ln 1, Col 12 - Ln 1, Col 12]",
+        "Operator [Ln 1, Col 14 - Ln 1, Col 14]",
+        "Number [Ln 1, Col 16 - Ln 1, Col 16]",
+        "Symbol [Ln 1, Col 17 - Ln 1, Col 17]",
+        "Variable [Ln 1, Col 19 - Ln 1, Col 19]",
+        "Operator [Ln 1, Col 21 - Ln 1, Col 21]",
+        "Number [Ln 1, Col 23 - Ln 1, Col 23]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestWhileWithSimpleStatementsAndFinalCommaBody() {
       string source = "while True: x = 1; y = 2;";
-      string expected = "[Ln 1, Col 0 - Ln 1, Col 23] WhileStatement\n" +
-                        "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)\n" +
-                        "  [Ln 1, Col 12 - Ln 1, Col 23] BlockStatement\n" +
-                        "    [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement\n" +
-                        "      [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x)\n" +
-                        "      [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)\n" +
-                        "    [Ln 1, Col 19 - Ln 1, Col 23] AssignmentStatement\n" +
-                        "      [Ln 1, Col 19 - Ln 1, Col 19] IdentifierExpression (y)\n" +
-                        "      [Ln 1, Col 23 - Ln 1, Col 23] NumberConstantExpression (2)";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 4]," +
-                              "Boolean [Ln 1, Col 6 - Ln 1, Col 9]," +
-                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                              "Variable [Ln 1, Col 12 - Ln 1, Col 12]," +
-                              "Operator [Ln 1, Col 14 - Ln 1, Col 14]," +
-                              "Number [Ln 1, Col 16 - Ln 1, Col 16]," +
-                              "Symbol [Ln 1, Col 17 - Ln 1, Col 17]," +
-                              "Variable [Ln 1, Col 19 - Ln 1, Col 19]," +
-                              "Operator [Ln 1, Col 21 - Ln 1, Col 21]," +
-                              "Number [Ln 1, Col 23 - Ln 1, Col 23]," +
-                              "Symbol [Ln 1, Col 24 - Ln 1, Col 24]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 1, Col 23] WhileStatement",
+        "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)",
+        "  [Ln 1, Col 12 - Ln 1, Col 23] BlockStatement",
+        "    [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement",
+        "      [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x) =",
+        "      [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)",
+        "    [Ln 1, Col 19 - Ln 1, Col 23] AssignmentStatement",
+        "      [Ln 1, Col 19 - Ln 1, Col 19] IdentifierExpression (y) =",
+        "      [Ln 1, Col 23 - Ln 1, Col 23] NumberConstantExpression (2)",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 4]",
+        "Boolean [Ln 1, Col 6 - Ln 1, Col 9]",
+        "Symbol [Ln 1, Col 10 - Ln 1, Col 10]",
+        "Variable [Ln 1, Col 12 - Ln 1, Col 12]",
+        "Operator [Ln 1, Col 14 - Ln 1, Col 14]",
+        "Number [Ln 1, Col 16 - Ln 1, Col 16]",
+        "Symbol [Ln 1, Col 17 - Ln 1, Col 17]",
+        "Variable [Ln 1, Col 19 - Ln 1, Col 19]",
+        "Operator [Ln 1, Col 21 - Ln 1, Col 21]",
+        "Number [Ln 1, Col 23 - Ln 1, Col 23]",
+        "Symbol [Ln 1, Col 24 - Ln 1, Col 24]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestFuncWithoutReturn() {
       string source = "def func(): x = 1";
-      string expected = "[Ln 1, Col 0 - Ln 1, Col 16] FuncDefStatement (func)\n" +
-                        "  [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement\n" +
-                        "    [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x)\n" +
-                        "    [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                              "Function [Ln 1, Col 4 - Ln 1, Col 7]," +
-                              "OpenParenthesis [Ln 1, Col 8 - Ln 1, Col 8]," +
-                              "CloseParenthesis [Ln 1, Col 9 - Ln 1, Col 9]," +
-                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                              "Variable [Ln 1, Col 12 - Ln 1, Col 12]," +
-                              "Operator [Ln 1, Col 14 - Ln 1, Col 14]," +
-                              "Number [Ln 1, Col 16 - Ln 1, Col 16]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 1, Col 16] FuncDefStatement (func)",
+        "  [Ln 1, Col 12 - Ln 1, Col 16] AssignmentStatement",
+        "    [Ln 1, Col 12 - Ln 1, Col 12] IdentifierExpression (x) =",
+        "    [Ln 1, Col 16 - Ln 1, Col 16] NumberConstantExpression (1)",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 2]",
+        "Function [Ln 1, Col 4 - Ln 1, Col 7]",
+        "OpenParenthesis [Ln 1, Col 8 - Ln 1, Col 8]",
+        "CloseParenthesis [Ln 1, Col 9 - Ln 1, Col 9]",
+        "Symbol [Ln 1, Col 10 - Ln 1, Col 10]",
+        "Variable [Ln 1, Col 12 - Ln 1, Col 12]",
+        "Operator [Ln 1, Col 14 - Ln 1, Col 14]",
+        "Number [Ln 1, Col 16 - Ln 1, Col 16]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestEmptyReturn() {
       string source = "def func(): return";
-      string expected = "[Ln 1, Col 0 - Ln 1, Col 17] FuncDefStatement (func)\n" +
-                        "  [Ln 1, Col 12 - Ln 1, Col 17] ReturnStatement";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                              "Function [Ln 1, Col 4 - Ln 1, Col 7]," +
-                              "OpenParenthesis [Ln 1, Col 8 - Ln 1, Col 8]," +
-                              "CloseParenthesis [Ln 1, Col 9 - Ln 1, Col 9]," +
-                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                              "Keyword [Ln 1, Col 12 - Ln 1, Col 17]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 1, Col 17] FuncDefStatement (func)",
+        "  [Ln 1, Col 12 - Ln 1, Col 17] ReturnStatement",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 2]",
+        "Function [Ln 1, Col 4 - Ln 1, Col 7]",
+        "OpenParenthesis [Ln 1, Col 8 - Ln 1, Col 8]",
+        "CloseParenthesis [Ln 1, Col 9 - Ln 1, Col 9]",
+        "Symbol [Ln 1, Col 10 - Ln 1, Col 10]",
+        "Keyword [Ln 1, Col 12 - Ln 1, Col 17]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestMultipleReturn() {
       string source = "def func():\n" +
                       "  return 1, 2, 3";
-      string expected = "[Ln 1, Col 0 - Ln 2, Col 15] FuncDefStatement (func)\n" +
-                        "  [Ln 2, Col 2 - Ln 2, Col 15] ReturnStatement\n" +
-                        "    [Ln 2, Col 9 - Ln 2, Col 9] NumberConstantExpression (1)\n" +
-                        "    [Ln 2, Col 12 - Ln 2, Col 12] NumberConstantExpression (2)\n" +
-                        "    [Ln 2, Col 15 - Ln 2, Col 15] NumberConstantExpression (3)";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                              "Function [Ln 1, Col 4 - Ln 1, Col 7]," +
-                              "OpenParenthesis [Ln 1, Col 8 - Ln 1, Col 8]," +
-                              "CloseParenthesis [Ln 1, Col 9 - Ln 1, Col 9]," +
-                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                              "Keyword [Ln 2, Col 2 - Ln 2, Col 7]," +
-                              "Number [Ln 2, Col 9 - Ln 2, Col 9]," +
-                              "Symbol [Ln 2, Col 10 - Ln 2, Col 10]," +
-                              "Number [Ln 2, Col 12 - Ln 2, Col 12]," +
-                              "Symbol [Ln 2, Col 13 - Ln 2, Col 13]," +
-                              "Number [Ln 2, Col 15 - Ln 2, Col 15]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 2, Col 15] FuncDefStatement (func)",
+        "  [Ln 2, Col 2 - Ln 2, Col 15] ReturnStatement",
+        "    [Ln 2, Col 9 - Ln 2, Col 9] NumberConstantExpression (1)",
+        "    [Ln 2, Col 12 - Ln 2, Col 12] NumberConstantExpression (2)",
+        "    [Ln 2, Col 15 - Ln 2, Col 15] NumberConstantExpression (3)",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 2]",
+        "Function [Ln 1, Col 4 - Ln 1, Col 7]",
+        "OpenParenthesis [Ln 1, Col 8 - Ln 1, Col 8]",
+        "CloseParenthesis [Ln 1, Col 9 - Ln 1, Col 9]",
+        "Symbol [Ln 1, Col 10 - Ln 1, Col 10]",
+        "Keyword [Ln 2, Col 2 - Ln 2, Col 7]",
+        "Number [Ln 2, Col 9 - Ln 2, Col 9]",
+        "Symbol [Ln 2, Col 10 - Ln 2, Col 10]",
+        "Number [Ln 2, Col 12 - Ln 2, Col 12]",
+        "Symbol [Ln 2, Col 13 - Ln 2, Col 13]",
+        "Number [Ln 2, Col 15 - Ln 2, Col 15]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
@@ -447,101 +557,118 @@ namespace SeedLang.X.Tests {
       string source = "def add(a, b):\n" +
                       "  c = a + b\n" +
                       "  return c";
-      string expected = "[Ln 1, Col 0 - Ln 3, Col 9] FuncDefStatement (add:a,b)\n" +
-                        "  [Ln 2, Col 2 - Ln 3, Col 9] BlockStatement\n" +
-                        "    [Ln 2, Col 2 - Ln 2, Col 10] AssignmentStatement\n" +
-                        "      [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (c)\n" +
-                        "      [Ln 2, Col 6 - Ln 2, Col 10] BinaryExpression (+)\n" +
-                        "        [Ln 2, Col 6 - Ln 2, Col 6] IdentifierExpression (a)\n" +
-                        "        [Ln 2, Col 10 - Ln 2, Col 10] IdentifierExpression (b)\n" +
-                        "    [Ln 3, Col 2 - Ln 3, Col 9] ReturnStatement\n" +
-                        "      [Ln 3, Col 9 - Ln 3, Col 9] IdentifierExpression (c)";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                              "Function [Ln 1, Col 4 - Ln 1, Col 6]," +
-                              "OpenParenthesis [Ln 1, Col 7 - Ln 1, Col 7]," +
-                              "Parameter [Ln 1, Col 8 - Ln 1, Col 8]," +
-                              "Symbol [Ln 1, Col 9 - Ln 1, Col 9]," +
-                              "Parameter [Ln 1, Col 11 - Ln 1, Col 11]," +
-                              "CloseParenthesis [Ln 1, Col 12 - Ln 1, Col 12]," +
-                              "Symbol [Ln 1, Col 13 - Ln 1, Col 13]," +
-                              "Variable [Ln 2, Col 2 - Ln 2, Col 2]," +
-                              "Operator [Ln 2, Col 4 - Ln 2, Col 4]," +
-                              "Variable [Ln 2, Col 6 - Ln 2, Col 6]," +
-                              "Operator [Ln 2, Col 8 - Ln 2, Col 8]," +
-                              "Variable [Ln 2, Col 10 - Ln 2, Col 10]," +
-                              "Keyword [Ln 3, Col 2 - Ln 3, Col 7]," +
-                              "Variable [Ln 3, Col 9 - Ln 3, Col 9]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] { "[Ln 1, Col 0 - Ln 3, Col 9] FuncDefStatement (add:a,b)",
+        "  [Ln 2, Col 2 - Ln 3, Col 9] BlockStatement",
+        "    [Ln 2, Col 2 - Ln 2, Col 10] AssignmentStatement",
+        "      [Ln 2, Col 2 - Ln 2, Col 2] IdentifierExpression (c) =",
+        "      [Ln 2, Col 6 - Ln 2, Col 10] BinaryExpression (+)",
+        "        [Ln 2, Col 6 - Ln 2, Col 6] IdentifierExpression (a)",
+        "        [Ln 2, Col 10 - Ln 2, Col 10] IdentifierExpression (b)",
+        "    [Ln 3, Col 2 - Ln 3, Col 9] ReturnStatement",
+        "      [Ln 3, Col 9 - Ln 3, Col 9] IdentifierExpression (c)",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 2]",
+        "Function [Ln 1, Col 4 - Ln 1, Col 6]",
+        "OpenParenthesis [Ln 1, Col 7 - Ln 1, Col 7]",
+        "Parameter [Ln 1, Col 8 - Ln 1, Col 8]",
+        "Symbol [Ln 1, Col 9 - Ln 1, Col 9]",
+        "Parameter [Ln 1, Col 11 - Ln 1, Col 11]",
+        "CloseParenthesis [Ln 1, Col 12 - Ln 1, Col 12]",
+        "Symbol [Ln 1, Col 13 - Ln 1, Col 13]",
+        "Variable [Ln 2, Col 2 - Ln 2, Col 2]",
+        "Operator [Ln 2, Col 4 - Ln 2, Col 4]",
+        "Variable [Ln 2, Col 6 - Ln 2, Col 6]",
+        "Operator [Ln 2, Col 8 - Ln 2, Col 8]",
+        "Variable [Ln 2, Col 10 - Ln 2, Col 10]",
+        "Keyword [Ln 3, Col 2 - Ln 3, Col 7]",
+        "Variable [Ln 3, Col 9 - Ln 3, Col 9]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestReturnBinary() {
       string source = "def add(a, b):\n" +
                       "  return a + b";
-      string expected = "[Ln 1, Col 0 - Ln 2, Col 13] FuncDefStatement (add:a,b)\n" +
-                        "  [Ln 2, Col 2 - Ln 2, Col 13] ReturnStatement\n" +
-                        "    [Ln 2, Col 9 - Ln 2, Col 13] BinaryExpression (+)\n" +
-                        "      [Ln 2, Col 9 - Ln 2, Col 9] IdentifierExpression (a)\n" +
-                        "      [Ln 2, Col 13 - Ln 2, Col 13] IdentifierExpression (b)";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                              "Function [Ln 1, Col 4 - Ln 1, Col 6]," +
-                              "OpenParenthesis [Ln 1, Col 7 - Ln 1, Col 7]," +
-                              "Parameter [Ln 1, Col 8 - Ln 1, Col 8]," +
-                              "Symbol [Ln 1, Col 9 - Ln 1, Col 9]," +
-                              "Parameter [Ln 1, Col 11 - Ln 1, Col 11]," +
-                              "CloseParenthesis [Ln 1, Col 12 - Ln 1, Col 12]," +
-                              "Symbol [Ln 1, Col 13 - Ln 1, Col 13]," +
-                              "Keyword [Ln 2, Col 2 - Ln 2, Col 7]," +
-                              "Variable [Ln 2, Col 9 - Ln 2, Col 9]," +
-                              "Operator [Ln 2, Col 11 - Ln 2, Col 11]," +
-                              "Variable [Ln 2, Col 13 - Ln 2, Col 13]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] {
+        "[Ln 1, Col 0 - Ln 2, Col 13] FuncDefStatement (add:a,b)",
+        "  [Ln 2, Col 2 - Ln 2, Col 13] ReturnStatement",
+        "    [Ln 2, Col 9 - Ln 2, Col 13] BinaryExpression (+)",
+        "      [Ln 2, Col 9 - Ln 2, Col 9] IdentifierExpression (a)",
+        "      [Ln 2, Col 13 - Ln 2, Col 13] IdentifierExpression (b)",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 2]",
+        "Function [Ln 1, Col 4 - Ln 1, Col 6]",
+        "OpenParenthesis [Ln 1, Col 7 - Ln 1, Col 7]",
+        "Parameter [Ln 1, Col 8 - Ln 1, Col 8]",
+        "Symbol [Ln 1, Col 9 - Ln 1, Col 9]",
+        "Parameter [Ln 1, Col 11 - Ln 1, Col 11]",
+        "CloseParenthesis [Ln 1, Col 12 - Ln 1, Col 12]",
+        "Symbol [Ln 1, Col 13 - Ln 1, Col 13]",
+        "Keyword [Ln 2, Col 2 - Ln 2, Col 7]",
+        "Variable [Ln 2, Col 9 - Ln 2, Col 9]",
+        "Operator [Ln 2, Col 11 - Ln 2, Col 11]",
+        "Variable [Ln 2, Col 13 - Ln 2, Col 13]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestBreak() {
       string source = "while True:\n" +
                       "  break";
-      string expected = "[Ln 1, Col 0 - Ln 2, Col 6] WhileStatement\n" +
-                        "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)\n" +
-                        "  [Ln 2, Col 2 - Ln 2, Col 6] BreakStatement";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 4]," +
-                              "Boolean [Ln 1, Col 6 - Ln 1, Col 9]," +
-                              "Symbol [Ln 1, Col 10 - Ln 1, Col 10]," +
-                              "Keyword [Ln 2, Col 2 - Ln 2, Col 6]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] {
+        "[Ln 1, Col 0 - Ln 2, Col 6] WhileStatement",
+        "  [Ln 1, Col 6 - Ln 1, Col 9] BooleanConstantExpression (True)",
+        "  [Ln 2, Col 2 - Ln 2, Col 6] BreakStatement",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 4]",
+        "Boolean [Ln 1, Col 6 - Ln 1, Col 9]",
+        "Symbol [Ln 1, Col 10 - Ln 1, Col 10]",
+        "Keyword [Ln 2, Col 2 - Ln 2, Col 6]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
     [Fact]
     public void TestContinue() {
       string source = "for i in range(10):\n" +
                       "  continue";
-      string expected = "[Ln 1, Col 0 - Ln 2, Col 9] ForInStatement\n" +
-                        "  [Ln 1, Col 4 - Ln 1, Col 4] IdentifierExpression (i)\n" +
-                        "  [Ln 1, Col 9 - Ln 1, Col 17] CallExpression\n" +
-                        "    [Ln 1, Col 9 - Ln 1, Col 13] IdentifierExpression (range)\n" +
-                        "    [Ln 1, Col 15 - Ln 1, Col 16] NumberConstantExpression (10)\n" +
-                        "  [Ln 2, Col 2 - Ln 2, Col 9] ContinueStatement";
-      string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 2]," +
-                              "Variable [Ln 1, Col 4 - Ln 1, Col 4]," +
-                              "Keyword [Ln 1, Col 6 - Ln 1, Col 7]," +
-                              "Variable [Ln 1, Col 9 - Ln 1, Col 13]," +
-                              "OpenParenthesis [Ln 1, Col 14 - Ln 1, Col 14]," +
-                              "Number [Ln 1, Col 15 - Ln 1, Col 16]," +
-                              "CloseParenthesis [Ln 1, Col 17 - Ln 1, Col 17]," +
-                              "Symbol [Ln 1, Col 18 - Ln 1, Col 18]," +
-                              "Keyword [Ln 2, Col 2 - Ln 2, Col 9]";
-      TestPythonParser(source, expected, expectedTokens);
+      var expectedAst = new string[] {
+        "[Ln 1, Col 0 - Ln 2, Col 9] ForInStatement",
+        "  [Ln 1, Col 4 - Ln 1, Col 4] IdentifierExpression (i)",
+        "  [Ln 1, Col 9 - Ln 1, Col 17] CallExpression",
+        "    [Ln 1, Col 9 - Ln 1, Col 13] IdentifierExpression (range)",
+        "    [Ln 1, Col 15 - Ln 1, Col 16] NumberConstantExpression (10)",
+        "  [Ln 2, Col 2 - Ln 2, Col 9] ContinueStatement",
+      };
+      var expectedTokens = new string[] {
+        "Keyword [Ln 1, Col 0 - Ln 1, Col 2]",
+        "Variable [Ln 1, Col 4 - Ln 1, Col 4]",
+        "Keyword [Ln 1, Col 6 - Ln 1, Col 7]",
+        "Variable [Ln 1, Col 9 - Ln 1, Col 13]",
+        "OpenParenthesis [Ln 1, Col 14 - Ln 1, Col 14]",
+        "Number [Ln 1, Col 15 - Ln 1, Col 16]",
+        "CloseParenthesis [Ln 1, Col 17 - Ln 1, Col 17]",
+        "Symbol [Ln 1, Col 18 - Ln 1, Col 18]",
+        "Keyword [Ln 2, Col 2 - Ln 2, Col 9]",
+      };
+      TestPythonParser(source, expectedAst, expectedTokens);
     }
 
-    private static void TestPythonParser(string source, string expected, string expectedTokens) {
+    private static void TestPythonParser(string source,
+                                         string[] expectedAst,
+                                         string[] expectedTokens) {
       var collection = new DiagnosticCollection();
-      Assert.True(new SeedPython().Parse(source, "", collection, out Statement statement,
-                                         out IReadOnlyList<TokenInfo> tokens));
-      Assert.NotNull(statement);
-      Assert.Empty(collection.Diagnostics);
-      Assert.Equal(expected.Replace("\n", Environment.NewLine), statement.ToString());
-      Assert.Equal(expectedTokens, string.Join(",", tokens));
+      new SeedPython().Parse(source, "", collection, out Statement statement,
+                             out IReadOnlyList<TokenInfo> tokens).Should().Be(true);
+      statement.Should().NotBe(null);
+      collection.Diagnostics.Should().BeEmpty();
+      statement.ToString().Split(Environment.NewLine).Should().BeEquivalentTo(expectedAst);
+      tokens.Select(token => token.ToString()).Should().BeEquivalentTo(expectedTokens);
     }
   }
 }

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonVTagTest.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonVTagTest.cs
@@ -48,7 +48,7 @@ namespace SeedLang.X.Tests {
                         "Initialize(x):\n" +
                         "[Ln 1, Col 34 - Ln 1, Col 34] IdentifierExpression (x))\n" +
                         "  [Ln 2, Col 0 - Ln 2, Col 8] AssignmentStatement\n" +
-                        "    [Ln 2, Col 0 - Ln 2, Col 0] IdentifierExpression (x)\n" +
+                        "    [Ln 2, Col 0 - Ln 2, Col 0] IdentifierExpression (x) =\n" +
                         "    [Ln 2, Col 4 - Ln 2, Col 8] BinaryExpression (+)\n" +
                         "      [Ln 2, Col 4 - Ln 2, Col 4] IdentifierExpression (y)\n" +
                         "      [Ln 2, Col 8 - Ln 2, Col 8] NumberConstantExpression (1)";
@@ -68,10 +68,10 @@ namespace SeedLang.X.Tests {
       string expected = "[Ln 1, Col 0 - Ln 3, Col 4] BlockStatement\n" +
                         "  [Ln 1, Col 0 - Ln 2, Col 4] VTagStatement (Assign,Initialize)\n" +
                         "    [Ln 2, Col 0 - Ln 2, Col 4] AssignmentStatement\n" +
-                        "      [Ln 2, Col 0 - Ln 2, Col 0] IdentifierExpression (x)\n" +
+                        "      [Ln 2, Col 0 - Ln 2, Col 0] IdentifierExpression (x) =\n" +
                         "      [Ln 2, Col 4 - Ln 2, Col 4] NumberConstantExpression (1)\n" +
                         "  [Ln 3, Col 0 - Ln 3, Col 4] AssignmentStatement\n" +
-                        "    [Ln 3, Col 0 - Ln 3, Col 0] IdentifierExpression (y)\n" +
+                        "    [Ln 3, Col 0 - Ln 3, Col 0] IdentifierExpression (y) =\n" +
                         "    [Ln 3, Col 4 - Ln 3, Col 4] NumberConstantExpression (2)";
       string expectedTokens = "Variable [Ln 2, Col 0 - Ln 2, Col 0]," +
                               "Operator [Ln 2, Col 2 - Ln 2, Col 2]," +
@@ -90,10 +90,10 @@ namespace SeedLang.X.Tests {
                       "# ]]";
       string expected = "[Ln 1, Col 0 - Ln 4, Col 3] VTagStatement (Assign,Initialize)\n" +
                         "  [Ln 2, Col 0 - Ln 2, Col 4] AssignmentStatement\n" +
-                        "    [Ln 2, Col 0 - Ln 2, Col 0] IdentifierExpression (x)\n" +
+                        "    [Ln 2, Col 0 - Ln 2, Col 0] IdentifierExpression (x) =\n" +
                         "    [Ln 2, Col 4 - Ln 2, Col 4] NumberConstantExpression (1)\n" +
                         "  [Ln 3, Col 0 - Ln 3, Col 4] AssignmentStatement\n" +
-                        "    [Ln 3, Col 0 - Ln 3, Col 0] IdentifierExpression (y)\n" +
+                        "    [Ln 3, Col 0 - Ln 3, Col 0] IdentifierExpression (y) =\n" +
                         "    [Ln 3, Col 4 - Ln 3, Col 4] NumberConstantExpression (2)";
       string expectedTokens = "Variable [Ln 2, Col 0 - Ln 2, Col 0]," +
                               "Operator [Ln 2, Col 2 - Ln 2, Col 2]," +
@@ -113,7 +113,7 @@ namespace SeedLang.X.Tests {
                         "  [Ln 1, Col 3 - Ln 1, Col 6] BooleanConstantExpression (True)\n" +
                         "  [Ln 2, Col 2 - Ln 3, Col 6] VTagStatement (Assign,Initialize)\n" +
                         "    [Ln 3, Col 2 - Ln 3, Col 6] AssignmentStatement\n" +
-                        "      [Ln 3, Col 2 - Ln 3, Col 2] IdentifierExpression (x)\n" +
+                        "      [Ln 3, Col 2 - Ln 3, Col 2] IdentifierExpression (x) =\n" +
                         "      [Ln 3, Col 6 - Ln 3, Col 6] NumberConstantExpression (1)";
       string expectedTokens = "Keyword [Ln 1, Col 0 - Ln 1, Col 1]," +
                               "Boolean [Ln 1, Col 3 - Ln 1, Col 6]," +
@@ -133,7 +133,7 @@ namespace SeedLang.X.Tests {
                         "  [Ln 2, Col 0 - Ln 3, Col 6] IfStatement\n" +
                         "    [Ln 2, Col 3 - Ln 2, Col 6] BooleanConstantExpression (True)\n" +
                         "    [Ln 3, Col 2 - Ln 3, Col 6] AssignmentStatement\n" +
-                        "      [Ln 3, Col 2 - Ln 3, Col 2] IdentifierExpression (x)\n" +
+                        "      [Ln 3, Col 2 - Ln 3, Col 2] IdentifierExpression (x) =\n" +
                         "      [Ln 3, Col 6 - Ln 3, Col 6] NumberConstantExpression (1)";
       string expectedTokens = "Keyword [Ln 2, Col 0 - Ln 2, Col 1]," +
                               "Boolean [Ln 2, Col 3 - Ln 2, Col 6]," +

--- a/examples/seedpython/scripts/sorting/merge_sort.py
+++ b/examples/seedpython/scripts/sorting/merge_sort.py
@@ -10,9 +10,7 @@ def merge_sort(a):
         merge_sort(left)
         merge_sort(right)
 
-        # TODO: Implement assigning the same value to multiple variables.
-        # i = j = k = 0
-        i, j, k = 0, 0, 0
+        i = j = k = 0
         while i < len(left) and j < len(right):
             if left[i] < right[j]:
                 a[k] = left[i]

--- a/grammars/SeedPython.g4
+++ b/grammars/SeedPython.g4
@@ -63,7 +63,7 @@ vtag_start: VTAG_START vtag (COMMA vtag)*;
 vtag: NAME (OPEN_PAREN arguments CLOSE_PAREN)?;
 
 assignment:
-  targets EQUAL expressions            # assign
+  (targets EQUAL)+ expressions         # assign
   | target ADD_ASSIGN expression       # add_assign
   | target SUBSTRACT_ASSIGN expression # substract_assign
   | target MULTIPLY_ASSIGN expression  # multiply_assign


### PR DESCRIPTION
Fix #198 

Following code is supported:
```python
a = b = 0
a = a[1] = [1, 2, 3]
```