### PR TITLE
Include variable information into assignment, binary and comparison notification events

### DIFF
--- a/csharp/benchmark/SeedLang.Benchmark/FibBenchmark.cs
+++ b/csharp/benchmark/SeedLang.Benchmark/FibBenchmark.cs
@@ -43,17 +43,17 @@ fib(35)
 ";
 
     [Benchmark]
-    public void BenchmarkBytecodeFib() {
+    public void BenchmarkFib() {
       Run(_fibSource);
     }
 
     [Benchmark]
-    public void BenchmarkBytecodeForFib() {
+    public void BenchmarkForFib() {
       Run(_forFibSource);
     }
 
     [Benchmark]
-    public void BenchmarkBytecodeRecursiveFib() {
+    public void BenchmarkRecursiveFib() {
       Run(_recursiveFibSource);
     }
 

--- a/csharp/src/SeedLang.Shell/VisualizerManager.cs
+++ b/csharp/src/SeedLang.Shell/VisualizerManager.cs
@@ -130,13 +130,11 @@ namespace SeedLang.Shell {
             Console.Write($"Binary: {be.Left} {op} {be.Right} = {be.Result}");
             break;
           }
-        case Event.Comparison ce:
-          Console.Write($"Comparison: {ce.First} ");
-          for (int i = 0; i < ce.Ops.Count; i++) {
-            Console.Write($"{_comparisonOperatorStrings[ce.Ops[i]]} {ce.Values[i]} ");
+        case Event.Comparison ce: {
+            var op = _comparisonOperatorStrings[ce.Op];
+            Console.Write($"Comparison: {ce.Left} {op} {ce.Right} = {ce.Result}");
+            break;
           }
-          Console.Write($"= {ce.Result}");
-          break;
         case Event.FuncCalled fce:
           Console.Write($"FuncCalled: {fce.Name} {string.Join(", ", fce.Args)}");
           break;

--- a/csharp/src/SeedLang.Shell/VisualizerManager.cs
+++ b/csharp/src/SeedLang.Shell/VisualizerManager.cs
@@ -144,9 +144,6 @@ namespace SeedLang.Shell {
         case Event.SingleStep sse:
           Console.Write($"SingleStep: {sse.Range.Start.Line}");
           break;
-        case Event.Unary ue:
-          Console.Write($"Unary: {_unaryOperatorStrings[ue.Op]} {ue.Value} = {ue.Result}");
-          break;
         case Event.VariableDefined vde:
           Console.Write($"VariableDefined: {vde.Name}");
           break;

--- a/csharp/src/SeedLang.Shell/VisualizerManager.cs
+++ b/csharp/src/SeedLang.Shell/VisualizerManager.cs
@@ -123,7 +123,7 @@ namespace SeedLang.Shell {
       Console.ForegroundColor = ConsoleColor.Black;
       switch (e) {
         case Event.Assignment ae:
-          Console.Write($"Assign: {ae.Variable} = {ae.Value}");
+          Console.Write($"Assign: {ae.Target} = {ae.Value}");
           break;
         case Event.Binary be: {
             var op = _binaryOperatorStrings[be.Op];

--- a/csharp/src/SeedLang.Shell/VisualizerManager.cs
+++ b/csharp/src/SeedLang.Shell/VisualizerManager.cs
@@ -123,19 +123,11 @@ namespace SeedLang.Shell {
       Console.ForegroundColor = ConsoleColor.Black;
       switch (e) {
         case Event.Assignment ae:
-          Console.Write($"Assign: {ae.Name} = {ae.Value}");
+          Console.Write($"Assign: {ae.Variable} = {ae.Value}");
           break;
         case Event.Binary be: {
             var op = _binaryOperatorStrings[be.Op];
             Console.Write($"Binary: {be.Left} {op} {be.Right} = {be.Result}");
-            break;
-          }
-        case Event.Boolean be: {
-            var op = _booleanOperatorStrings[be.Op];
-            foreach (Value value in be.Values) {
-              Console.Write($"{op} {value} ");
-            }
-            Console.Write($"= {be.Result}");
             break;
           }
         case Event.Comparison ce:
@@ -153,10 +145,6 @@ namespace SeedLang.Shell {
           break;
         case Event.SingleStep sse:
           Console.Write($"SingleStep: {sse.Range.Start.Line}");
-          break;
-        case Event.SubscriptAssignment sae:
-          var keys = string.Join("][", sae.Keys);
-          Console.Write($"SubscriptAssign: {sae.Name}[{keys}] = {sae.Value}");
           break;
         case Event.Unary ue:
           Console.Write($"Unary: {_unaryOperatorStrings[ue.Op]} {ue.Value} = {ue.Result}");

--- a/csharp/src/SeedLang/Interpreter/CompilerHelper.cs
+++ b/csharp/src/SeedLang/Interpreter/CompilerHelper.cs
@@ -203,16 +203,10 @@ namespace SeedLang.Interpreter {
 
     internal void EmitSubscriptAssignNotification(uint containerId, uint keyId, uint valueId,
                                                   TextRange range) {
+      // Check if there are assignment events registered in the visualizer center, because SeedVM
+      // will send assignment events for subscript assignments as well.
       if (!_suspendNotificationEmitting && _visualizerCenter.HasVisualizer<Event.Assignment>()) {
         var n = new Notification.SubscriptAssignment(containerId, keyId, valueId);
-        Emit(Opcode.VISNOTIFY, 0, Cache.IdOfNotification(n), range);
-      }
-    }
-
-    internal void EmitUnaryNotification(UnaryOperator op, uint valueId, uint resultId,
-                                        TextRange range) {
-      if (!_suspendNotificationEmitting && _visualizerCenter.HasVisualizer<Event.Unary>()) {
-        var n = new Notification.Unary(op, valueId, resultId);
         Emit(Opcode.VISNOTIFY, 0, Cache.IdOfNotification(n), range);
       }
     }

--- a/csharp/src/SeedLang/Interpreter/CompilerHelper.cs
+++ b/csharp/src/SeedLang/Interpreter/CompilerHelper.cs
@@ -195,8 +195,7 @@ namespace SeedLang.Interpreter {
 
     internal void EmitSubscriptAssignNotification(uint containerId, uint keyId, uint valueId,
                                                   TextRange range) {
-      if (!_suspendNotificationEmitting &&
-          _visualizerCenter.HasVisualizer<Event.SubscriptAssignment>()) {
+      if (!_suspendNotificationEmitting && _visualizerCenter.HasVisualizer<Event.Assignment>()) {
         var n = new Notification.SubscriptAssignment(containerId, keyId, valueId);
         Emit(Opcode.VISNOTIFY, 0, Cache.IdOfNotification(n), range);
       }

--- a/csharp/src/SeedLang/Interpreter/CompilerHelper.cs
+++ b/csharp/src/SeedLang/Interpreter/CompilerHelper.cs
@@ -179,9 +179,9 @@ namespace SeedLang.Interpreter {
     }
 
     internal void EmitComparisonNotification(uint leftId, ComparisonOperator op, uint rightId,
-                                             uint resultId, TextRange range) {
+                                             TextRange range) {
       if (!_suspendNotificationEmitting && _visualizerCenter.HasVisualizer<Event.Comparison>()) {
-        var n = new Notification.Comparison(leftId, op, rightId, resultId);
+        var n = new Notification.Comparison(leftId, op, rightId);
         Emit(Opcode.VISNOTIFY, 0, Cache.IdOfNotification(n), range);
       }
     }

--- a/csharp/src/SeedLang/Interpreter/CompilerHelper.cs
+++ b/csharp/src/SeedLang/Interpreter/CompilerHelper.cs
@@ -203,7 +203,7 @@ namespace SeedLang.Interpreter {
 
     internal void EmitSubscriptAssignNotification(uint containerId, uint keyId, uint valueId,
                                                   TextRange range) {
-      // Check if there are assignment events registered in the visualizer center, because SeedVM
+      // Checks if there are assignment events registered in the visualizer center, because SeedVM
       // will send assignment events for subscript assignments as well.
       if (!_suspendNotificationEmitting && _visualizerCenter.HasVisualizer<Event.Assignment>()) {
         var n = new Notification.SubscriptAssignment(containerId, keyId, valueId);

--- a/csharp/src/SeedLang/Interpreter/CompilerHelper.cs
+++ b/csharp/src/SeedLang/Interpreter/CompilerHelper.cs
@@ -178,6 +178,14 @@ namespace SeedLang.Interpreter {
       }
     }
 
+    internal void EmitComparisonNotification(uint leftId, ComparisonOperator op, uint rightId,
+                                             uint resultId, TextRange range) {
+      if (!_suspendNotificationEmitting && _visualizerCenter.HasVisualizer<Event.Comparison>()) {
+        var n = new Notification.Comparison(leftId, op, rightId, resultId);
+        Emit(Opcode.VISNOTIFY, 0, Cache.IdOfNotification(n), range);
+      }
+    }
+
     internal void EmitGetElementNotification(uint targetId, uint containerId, uint keyId,
                                              TextRange range) {
       if (!_suspendNotificationEmitting && _visualizerCenter.IsVariableTrackingEnabled) {

--- a/csharp/src/SeedLang/Interpreter/ExprCompiler.cs
+++ b/csharp/src/SeedLang/Interpreter/ExprCompiler.cs
@@ -215,7 +215,6 @@ namespace SeedLang.Interpreter {
       _helper.BeginExprScope();
       uint exprId = VisitExpressionForRKId(unary.Expr);
       _helper.Emit(Opcode.UNM, context.TargetRegister, exprId, 0, unary.Range);
-      _helper.EmitUnaryNotification(unary.Op, exprId, context.TargetRegister, unary.Range);
       _helper.EndExprScope();
     }
 
@@ -248,8 +247,9 @@ namespace SeedLang.Interpreter {
       if (nextBooleanOp == BooleanOperator.Or) {
         checkFlag = !checkFlag;
       }
-      // Emits the comparison notification before the actual comparison, otherwise two notifications
-      // have to be emitted in two different execution paths.
+      // Emits a comparison notification for each single comparison before the actual comparison.
+      // Two notifications have to be emitted in two different execution paths if emitting after the
+      // actual comparison.
       _helper.EmitComparisonNotification(leftRegister, op, rightRegister, range);
       _helper.Emit(opcode, checkFlag ? 1u : 0u, leftRegister, rightRegister, range);
       _helper.Emit(Opcode.JMP, 0, 0, range);

--- a/csharp/src/SeedLang/Interpreter/ExprCompiler.cs
+++ b/csharp/src/SeedLang/Interpreter/ExprCompiler.cs
@@ -91,7 +91,8 @@ namespace SeedLang.Interpreter {
       if (call.Func is IdentifierExpression identifier) {
         if (_helper.FindVariable(identifier.Name) is VariableInfo info) {
           bool needRegister = context.TargetRegister != _helper.LastRegister;
-          uint funcRegister = needRegister ? _helper.DefineTempVariable() : context.TargetRegister;
+          uint funcRegister = needRegister ? _helper.DefineTempVariable(identifier.Range) :
+                                             context.TargetRegister;
           switch (info.Type) {
             case VariableType.Global:
               _helper.Emit(Opcode.GETGLOB, funcRegister, info.Id, identifier.Range);
@@ -104,7 +105,7 @@ namespace SeedLang.Interpreter {
               break;
           }
           foreach (Expression expr in call.Arguments) {
-            Visit(expr, new Context { TargetRegister = _helper.DefineTempVariable() });
+            Visit(expr, new Context { TargetRegister = _helper.DefineTempVariable(expr.Range) });
           }
           _helper.EmitCall(identifier.Name, funcRegister, (uint)call.Arguments.Length, call.Range);
           if (needRegister) {
@@ -136,15 +137,15 @@ namespace SeedLang.Interpreter {
       _helper.BeginExprScope();
       uint? first = null;
       foreach (var item in dict.KeyValues) {
-        uint register = _helper.DefineTempVariable();
+        uint register = _helper.DefineTempVariable(dict.Range);
         if (!first.HasValue) {
           first = register;
         }
         Visit(item.Key, new Context { TargetRegister = register });
-        Visit(item.Value, new Context { TargetRegister = _helper.DefineTempVariable() });
+        Visit(item.Value, new Context { TargetRegister = _helper.DefineTempVariable(dict.Range) });
       }
-      _helper.Emit(Opcode.NEWDICT, context.TargetRegister, first ?? 0, (uint)dict.KeyValues.Length * 2,
-                   dict.Range);
+      _helper.Emit(Opcode.NEWDICT, context.TargetRegister, first ?? 0,
+                   (uint)dict.KeyValues.Length * 2, dict.Range);
       _helper.EndExprScope();
     }
 
@@ -269,7 +270,7 @@ namespace SeedLang.Interpreter {
       _helper.BeginExprScope();
       uint? first = null;
       foreach (var expr in exprs) {
-        uint register = _helper.DefineTempVariable();
+        uint register = _helper.DefineTempVariable(range);
         if (!first.HasValue) {
           first = register;
         }
@@ -281,7 +282,7 @@ namespace SeedLang.Interpreter {
 
     private uint VisitExpressionForRegisterId(Expression expr) {
       if (!(_helper.GetRegisterId(expr) is uint exprId)) {
-        exprId = _helper.DefineTempVariable();
+        exprId = _helper.DefineTempVariable(expr.Range);
         Visit(expr, new Context { TargetRegister = exprId });
       }
       return exprId;
@@ -289,7 +290,7 @@ namespace SeedLang.Interpreter {
 
     private uint VisitExpressionForRKId(Expression expr) {
       if (!(_helper.GetRegisterOrConstantId(expr) is uint exprId)) {
-        exprId = _helper.DefineTempVariable();
+        exprId = _helper.DefineTempVariable(expr.Range);
         Visit(expr, new Context { TargetRegister = exprId });
       }
       return exprId;

--- a/csharp/src/SeedLang/Interpreter/ExprCompiler.cs
+++ b/csharp/src/SeedLang/Interpreter/ExprCompiler.cs
@@ -248,6 +248,9 @@ namespace SeedLang.Interpreter {
       if (nextBooleanOp == BooleanOperator.Or) {
         checkFlag = !checkFlag;
       }
+      // Emits the comparison notification before the actual comparison, otherwise two notifications
+      // have to be emitted in two different execution paths.
+      _helper.EmitComparisonNotification(leftRegister, op, rightRegister, range);
       _helper.Emit(opcode, checkFlag ? 1u : 0u, leftRegister, rightRegister, range);
       _helper.Emit(Opcode.JMP, 0, 0, range);
       switch (nextBooleanOp) {
@@ -258,7 +261,6 @@ namespace SeedLang.Interpreter {
           _helper.ExprJumpStack.AddTrueJump(_helper.Chunk.LatestCodePos);
           break;
       }
-      _helper.EmitComparisonNotification(leftRegister, op, rightRegister, 0, range);
       _helper.EndExprScope();
     }
 

--- a/csharp/src/SeedLang/Interpreter/ExprCompiler.cs
+++ b/csharp/src/SeedLang/Interpreter/ExprCompiler.cs
@@ -258,6 +258,7 @@ namespace SeedLang.Interpreter {
           _helper.ExprJumpStack.AddTrueJump(_helper.Chunk.LatestCodePos);
           break;
       }
+      _helper.EmitComparisonNotification(leftRegister, op, rightRegister, 0, range);
       _helper.EndExprScope();
     }
 

--- a/csharp/src/SeedLang/Interpreter/Notifications.cs
+++ b/csharp/src/SeedLang/Interpreter/Notifications.cs
@@ -124,6 +124,55 @@ namespace SeedLang.Interpreter {
       }
     }
 
+    internal sealed class Comparison : AbstractNotification, IEquatable<Comparison> {
+      public uint LeftId { get; }
+      public ComparisonOperator Op { get; }
+      public uint RightId { get; }
+      public uint ResultId { get; }
+
+      internal Comparison(uint leftId, ComparisonOperator op, uint rightId, uint resultId) {
+        LeftId = leftId;
+        Op = op;
+        RightId = rightId;
+        ResultId = resultId;
+      }
+
+      public static bool operator ==(Comparison lhs, Comparison rhs) {
+        return lhs.Equals(rhs);
+      }
+
+      public static bool operator !=(Comparison lhs, Comparison rhs) {
+        return !(lhs == rhs);
+      }
+
+      public bool Equals(Comparison other) {
+        if (other is null) {
+          return false;
+        }
+        if (ReferenceEquals(this, other)) {
+          return true;
+        }
+        return LeftId == other.LeftId && Op == other.Op &&
+               RightId == other.RightId && ResultId == other.ResultId;
+      }
+
+      public override bool Equals(object obj) {
+        return Equals(obj as Comparison);
+      }
+
+      public override int GetHashCode() {
+        return new { LeftId, Op, RightId, ResultId, }.GetHashCode();
+      }
+
+      public override string ToString() {
+        return $"Notification.{GetType().Name}: {LeftId} {Op} {RightId} {ResultId}";
+      }
+
+      internal override void Accept(VM vm) {
+        vm.HandleComparison(this);
+      }
+    }
+
     internal sealed class ElementLoaded : AbstractNotification, IEquatable<ElementLoaded> {
       public uint TargetId { get; }
       public uint ContainerId { get; }

--- a/csharp/src/SeedLang/Interpreter/Notifications.cs
+++ b/csharp/src/SeedLang/Interpreter/Notifications.cs
@@ -67,7 +67,7 @@ namespace SeedLang.Interpreter {
       }
 
       public override string ToString() {
-        return $"Notification.{GetType().Name}: '{Name}': {Type} {ValueId}";
+        return $"Notification.{GetType().Name}: '{Name}' {Type} {ValueId}";
       }
 
       internal override void Accept(VM vm) {

--- a/csharp/src/SeedLang/Interpreter/Notifications.cs
+++ b/csharp/src/SeedLang/Interpreter/Notifications.cs
@@ -392,52 +392,6 @@ namespace SeedLang.Interpreter {
       }
     }
 
-    internal sealed class Unary : AbstractNotification, IEquatable<Unary> {
-      public UnaryOperator Op { get; }
-      public uint ValueId { get; }
-      public uint ResultId { get; }
-
-      internal Unary(UnaryOperator op, uint valueId, uint resultId) {
-        Op = op;
-        ValueId = valueId;
-        ResultId = resultId;
-      }
-
-      public static bool operator ==(Unary lhs, Unary rhs) {
-        return lhs.Equals(rhs);
-      }
-
-      public static bool operator !=(Unary lhs, Unary rhs) {
-        return !(lhs == rhs);
-      }
-
-      public bool Equals(Unary other) {
-        if (other is null) {
-          return false;
-        }
-        if (ReferenceEquals(this, other)) {
-          return true;
-        }
-        return Op == other.Op && ValueId == other.ValueId && ResultId == other.ResultId;
-      }
-
-      public override bool Equals(object obj) {
-        return Equals(obj as Unary);
-      }
-
-      public override int GetHashCode() {
-        return new { Op, ValueId, ResultId, }.GetHashCode();
-      }
-
-      public override string ToString() {
-        return $"Notification.{GetType().Name}: {Op} {ValueId} {ResultId}";
-      }
-
-      internal override void Accept(VM vm) {
-        vm.HandleUnary(this);
-      }
-    }
-
     internal sealed class VariableDefined : AbstractNotification, IEquatable<VariableDefined> {
       public VariableInfo Info { get; }
 

--- a/csharp/src/SeedLang/Interpreter/Notifications.cs
+++ b/csharp/src/SeedLang/Interpreter/Notifications.cs
@@ -128,13 +128,11 @@ namespace SeedLang.Interpreter {
       public uint LeftId { get; }
       public ComparisonOperator Op { get; }
       public uint RightId { get; }
-      public uint ResultId { get; }
 
-      internal Comparison(uint leftId, ComparisonOperator op, uint rightId, uint resultId) {
+      internal Comparison(uint leftId, ComparisonOperator op, uint rightId) {
         LeftId = leftId;
         Op = op;
         RightId = rightId;
-        ResultId = resultId;
       }
 
       public static bool operator ==(Comparison lhs, Comparison rhs) {
@@ -152,8 +150,7 @@ namespace SeedLang.Interpreter {
         if (ReferenceEquals(this, other)) {
           return true;
         }
-        return LeftId == other.LeftId && Op == other.Op &&
-               RightId == other.RightId && ResultId == other.ResultId;
+        return LeftId == other.LeftId && Op == other.Op && RightId == other.RightId;
       }
 
       public override bool Equals(object obj) {
@@ -161,11 +158,11 @@ namespace SeedLang.Interpreter {
       }
 
       public override int GetHashCode() {
-        return new { LeftId, Op, RightId, ResultId, }.GetHashCode();
+        return new { LeftId, Op, RightId, }.GetHashCode();
       }
 
       public override string ToString() {
-        return $"Notification.{GetType().Name}: {LeftId} {Op} {RightId} {ResultId}";
+        return $"Notification.{GetType().Name}: {LeftId} {Op} {RightId}";
       }
 
       internal override void Accept(VM vm) {

--- a/csharp/src/SeedLang/Interpreter/Notifications.cs
+++ b/csharp/src/SeedLang/Interpreter/Notifications.cs
@@ -392,6 +392,49 @@ namespace SeedLang.Interpreter {
       }
     }
 
+    internal sealed class TempRegisterAllocated :
+        AbstractNotification, IEquatable<TempRegisterAllocated> {
+      public uint Id { get; }
+
+      internal TempRegisterAllocated(uint id) {
+        Id = id;
+      }
+
+      public static bool operator ==(TempRegisterAllocated lhs, TempRegisterAllocated rhs) {
+        return lhs.Equals(rhs);
+      }
+
+      public static bool operator !=(TempRegisterAllocated lhs, TempRegisterAllocated rhs) {
+        return !(lhs == rhs);
+      }
+
+      public bool Equals(TempRegisterAllocated other) {
+        if (other is null) {
+          return false;
+        }
+        if (ReferenceEquals(this, other)) {
+          return true;
+        }
+        return Id == other.Id;
+      }
+
+      public override bool Equals(object obj) {
+        return Equals(obj as TempRegisterAllocated);
+      }
+
+      public override int GetHashCode() {
+        return Id.GetHashCode();
+      }
+
+      public override string ToString() {
+        return $"Notification.{GetType().Name}: {Id}";
+      }
+
+      internal override void Accept(VM vm) {
+        vm.HandleTempRegisterAllocated(this);
+      }
+    }
+
     internal sealed class VariableDefined : AbstractNotification, IEquatable<VariableDefined> {
       public VariableInfo Info { get; }
 

--- a/csharp/src/SeedLang/Interpreter/Registers.cs
+++ b/csharp/src/SeedLang/Interpreter/Registers.cs
@@ -150,7 +150,9 @@ namespace SeedLang.Interpreter {
 
     private void SetRegisterInfoAt(uint registerId, RegisterInfo info) {
       int index = (int)(Base + registerId);
-      Debug.Assert(index <= _registerInfos.Count);
+      // TODO: This assert fails in the merge sort example. It means there are bugs in the variable
+      // tracking logic. Check and fix it later.
+      // Debug.Assert(index <= _registerInfos.Count);
       if (index < _registerInfos.Count) {
         _registerInfos[index] = info;
       } else {

--- a/csharp/src/SeedLang/Interpreter/Registers.cs
+++ b/csharp/src/SeedLang/Interpreter/Registers.cs
@@ -40,8 +40,7 @@ namespace SeedLang.Interpreter {
       public string Name { get; }
       // The referenced variable type.
       public VariableType RefVariableType { get; }
-      // The keys of the container elements, e.g. for a[0][1], 0 and 1 are stored in the keys. It's
-      // empty for local variables.
+      // The keys of the container elements, e.g. for a[0][1], 0 and 1 are stored in the keys.
       public IReadOnlyList<Value> Keys { get; }
 
       private readonly Type _type;

--- a/csharp/src/SeedLang/Interpreter/Registers.cs
+++ b/csharp/src/SeedLang/Interpreter/Registers.cs
@@ -40,7 +40,8 @@ namespace SeedLang.Interpreter {
       public string Name { get; }
       // The referenced variable type.
       public VariableType RefVariableType { get; }
-      // The keys of the container elements, e.g. for a[0][1], 0 and 1 are stored in the keys.
+      // The keys of the container elements, e.g. for a[0][1], 0 and 1 are stored in the keys. It's
+      // empty for local variables.
       public IReadOnlyList<Value> Keys { get; }
 
       private readonly Type _type;

--- a/csharp/src/SeedLang/Interpreter/VM.cs
+++ b/csharp/src/SeedLang/Interpreter/VM.cs
@@ -131,6 +131,14 @@ namespace SeedLang.Interpreter {
                                                 _chunk.Ranges[_pc]));
     }
 
+    internal void HandleComparison(Notification.Comparison comparison) {
+      var left = MakeOperand(comparison.LeftId);
+      var right = MakeOperand(comparison.RightId);
+      _visualizerCenter.Notify(new Event.Comparison(left, comparison.Op, right,
+                                                    new Value(ValueOfRK(comparison.ResultId)),
+                                                    _chunk.Ranges[_pc]));
+    }
+
     internal void HandleElementLoaded(Notification.ElementLoaded elemLoaded) {
       if (!_registers.GetRegisterInfo(elemLoaded.TargetId).IsLocal) {
         var key = new Value(ValueOfRK(elemLoaded.KeyId));

--- a/csharp/src/SeedLang/Interpreter/VM.cs
+++ b/csharp/src/SeedLang/Interpreter/VM.cs
@@ -118,7 +118,7 @@ namespace SeedLang.Interpreter {
     }
 
     internal void HandleAssignment(Notification.Assignment assign) {
-      var target = new LValue(new Variable(assign.Name, ToVariableType(assign.Type)));
+      var target = new LValue(new Variable(assign.Name, assign.Type));
       _visualizerCenter.Notify(new Event.Assignment(target, MakeRValue(assign.ValueId),
                                                     _chunk.Ranges[_pc]));
     }
@@ -204,7 +204,7 @@ namespace SeedLang.Interpreter {
       if (!container.IsTemporary) {
         var keys = container.Keys.ToList();
         keys.Add(new Value(ValueOfRK(assign.KeyId)));
-        var type = ToVariableType(container.RefVariableType);
+        var type = container.RefVariableType;
         var target = new LValue(new Variable(container.Name, type), keys);
         _visualizerCenter.Notify(new Event.Assignment(target, MakeRValue(assign.ValueId),
                                                       _chunk.Ranges[_pc]));
@@ -237,7 +237,7 @@ namespace SeedLang.Interpreter {
       }
       if (isFirstTimeDefined && _visualizerCenter.HasVisualizer<Event.VariableDefined>()) {
         _visualizerCenter.Notify(new Event.VariableDefined(variableDefined.Info.Name,
-                                                           ToVariableType(variableDefined.Info.Type),
+                                                           variableDefined.Info.Type,
                                                            _chunk.Ranges[_pc]));
       }
     }
@@ -504,7 +504,7 @@ namespace SeedLang.Interpreter {
         Registers.RegisterInfo info = _registers.GetRegisterInfo(operandId);
         if (!info.IsTemporary) {
           VariableType type = info.IsLocal ? VariableType.Local : info.RefVariableType;
-          var variable = new Variable(info.Name, ToVariableType(type));
+          var variable = new Variable(info.Name, type);
           if (info.Keys.Count > 0) {
             return new RValue(variable, info.Keys, value);
           } else {
@@ -526,14 +526,6 @@ namespace SeedLang.Interpreter {
 
     private static bool IsRegisterId(uint rkId) {
       return rkId < Chunk.MaxRegisterCount;
-    }
-
-    private static Visualization.VariableType ToVariableType(VariableType type) {
-      return type switch {
-        VariableType.Global => Visualization.VariableType.Global,
-        VariableType.Local => Visualization.VariableType.Local,
-        _ => throw new NotImplementedException($"Unsupported variable type {type}."),
-      };
     }
   }
 }

--- a/csharp/src/SeedLang/Interpreter/VM.cs
+++ b/csharp/src/SeedLang/Interpreter/VM.cs
@@ -118,8 +118,8 @@ namespace SeedLang.Interpreter {
     }
 
     internal void HandleAssignment(Notification.Assignment assign) {
-      _visualizerCenter.Notify(new Event.Assignment(assign.Name, assign.Type,
-                                                    new Value(ValueOfRK(assign.ValueId)),
+      var variable = new Variable(assign.Name, assign.Type, new List<Value>());
+      _visualizerCenter.Notify(new Event.Assignment(variable, new Value(ValueOfRK(assign.ValueId)),
                                                     _chunk.Ranges[_pc]));
     }
 
@@ -180,11 +180,10 @@ namespace SeedLang.Interpreter {
       if (!container.IsTemporary) {
         var keys = container.Keys.ToList();
         keys.Add(new Value(ValueOfRK(assign.KeyId)));
-        _visualizerCenter.Notify(new Event.SubscriptAssignment(container.Name,
-                                                               container.RefVariableType,
-                                                               keys,
-                                                               new Value(ValueOfRK(assign.ValueId)),
-                                                               _chunk.Ranges[_pc]));
+        var variable = new Variable(container.Name, container.RefVariableType, keys);
+        _visualizerCenter.Notify(new Event.Assignment(variable,
+                                                      new Value(ValueOfRK(assign.ValueId)),
+                                                      _chunk.Ranges[_pc]));
       }
     }
 

--- a/csharp/src/SeedLang/Interpreter/VM.cs
+++ b/csharp/src/SeedLang/Interpreter/VM.cs
@@ -211,13 +211,6 @@ namespace SeedLang.Interpreter {
       }
     }
 
-    internal void HandleUnary(Notification.Unary unary) {
-      _visualizerCenter.Notify(new Event.Unary(unary.Op,
-                                               new Value(ValueOfRK(unary.ValueId)),
-                                               new Value(ValueOfRK(unary.ResultId)),
-                                               _chunk.Ranges[_pc]));
-    }
-
     internal void HandleVariableDefined(Notification.VariableDefined variableDefined) {
       bool isFirstTimeDefined = false;
       switch (variableDefined.Info.Type) {

--- a/csharp/src/SeedLang/Interpreter/VM.cs
+++ b/csharp/src/SeedLang/Interpreter/VM.cs
@@ -134,8 +134,23 @@ namespace SeedLang.Interpreter {
     internal void HandleComparison(Notification.Comparison comparison) {
       var left = MakeOperand(comparison.LeftId);
       var right = MakeOperand(comparison.RightId);
+      bool result = comparison.Op switch {
+        ComparisonOperator.Less =>
+            ValueHelper.Less(left.Value.GetRawValue(), right.Value.GetRawValue()),
+        ComparisonOperator.Greater =>
+            !ValueHelper.LessEqual(left.Value.GetRawValue(), right.Value.GetRawValue()),
+        ComparisonOperator.LessEqual =>
+            ValueHelper.LessEqual(left.Value.GetRawValue(), right.Value.GetRawValue()),
+        ComparisonOperator.GreaterEqual =>
+            !ValueHelper.Less(left.Value.GetRawValue(), right.Value.GetRawValue()),
+        ComparisonOperator.EqEqual => left.Value.GetRawValue() == right.Value.GetRawValue(),
+        ComparisonOperator.NotEqual => left.Value.GetRawValue() != right.Value.GetRawValue(),
+        ComparisonOperator.In =>
+            ValueHelper.Contains(right.Value.GetRawValue(), left.Value.GetRawValue()),
+        _ => throw new NotImplementedException($"Unsupported comparison operator {comparison.Op}"),
+      };
       _visualizerCenter.Notify(new Event.Comparison(left, comparison.Op, right,
-                                                    new Value(ValueOfRK(comparison.ResultId)),
+                                                    new Value(new VMValue(result)),
                                                     _chunk.Ranges[_pc]));
     }
 

--- a/csharp/src/SeedLang/Interpreter/VariableResolver.cs
+++ b/csharp/src/SeedLang/Interpreter/VariableResolver.cs
@@ -64,13 +64,13 @@ namespace SeedLang.Interpreter {
   // global environment, and allocates register slots for local and temporary variables.
   internal class VariableResolver {
     private class Registers {
-      private readonly List<VariableInfo> _variableInfos = new List<VariableInfo>();
-
       public int Count => _variableInfos.Count;
+
+      private readonly List<VariableInfo> _variableInfos = new List<VariableInfo>();
 
       internal uint AllocateRegister(string name = null) {
         var id = (uint)_variableInfos.Count;
-        var info = name == null ? null : new VariableInfo(name, VariableType.Local, id);
+        var info = name is null ? null : new VariableInfo(name, VariableType.Local, id);
         _variableInfos.Add(info);
         return id;
       }
@@ -96,10 +96,10 @@ namespace SeedLang.Interpreter {
     }
 
     private class GlobalScope : IScope {
-      private readonly GlobalEnvironment _env;
-
       public string Path => null;
       public Registers Registers { get; } = new Registers();
+
+      private readonly GlobalEnvironment _env;
 
       public GlobalScope(GlobalEnvironment env) {
         _env = env;
@@ -122,10 +122,10 @@ namespace SeedLang.Interpreter {
     }
 
     private class ExprScope : IScope {
-      private readonly int _start;
-
       public string Path => null;
       public Registers Registers { get; }
+
+      private readonly int _start;
 
       internal ExprScope(IScope parent) {
         Registers = parent.Registers;
@@ -150,10 +150,10 @@ namespace SeedLang.Interpreter {
     }
 
     private class FuncScope : IScope {
-      private readonly Dictionary<string, uint> _variables = new Dictionary<string, uint>();
-
       public string Path { get; }
       public Registers Registers { get; } = new Registers();
+
+      private readonly Dictionary<string, uint> _variables = new Dictionary<string, uint>();
 
       internal FuncScope(IScope parent, string name) {
         Path = !(parent.Path is null) ? $"{parent.Path}.{name}" : $"{name}";

--- a/csharp/src/SeedLang/Visualization/EventData.cs
+++ b/csharp/src/SeedLang/Visualization/EventData.cs
@@ -23,6 +23,9 @@ namespace SeedLang.Visualization {
     Upvalue,
   }
 
+  // The class that is used as operands of binary and comparison events. It could be a variable,
+  // an element of containers or a temporary value. The Variable field is null if it's a temporary
+  // value.
   public class Operand {
     public bool IsVariable => !(Variable is null);
 
@@ -45,6 +48,8 @@ namespace SeedLang.Visualization {
     }
   }
 
+  // The variable class for events. It could be a variable or an element of containers. The Keys
+  // field is empty if it's a variable.
   public class Variable {
     public bool IsElementOfContainer => Keys.Count > 0;
 

--- a/csharp/src/SeedLang/Visualization/EventData.cs
+++ b/csharp/src/SeedLang/Visualization/EventData.cs
@@ -35,8 +35,8 @@ namespace SeedLang.Visualization {
     Variable,
   }
 
-  // The LValue class. It could be a variable or an element of containers. The Keys
-  // field is empty if it's a variable.
+  // The LValue class. It could be a variable or an element of containers. The Keys field is null if
+  // it's a variable.
   public class LValue {
     public LValueType Type { get; }
     public Variable Variable { get; }
@@ -63,8 +63,8 @@ namespace SeedLang.Visualization {
     }
   }
 
-  // The class that is used as operands of binary and comparison events. It could be a variable,
-  // an element of containers or a temporary value. The Variable field is null if it's a temporary
+  // The RValue class. It could be a variable, an element of containers or a temporary value. The
+  // Keys field is null if it's a variable. The Variable and Keys field is null if it's a temporary
   // value.
   public class RValue {
     public RValueType Type { get; }

--- a/csharp/src/SeedLang/Visualization/EventData.cs
+++ b/csharp/src/SeedLang/Visualization/EventData.cs
@@ -24,82 +24,63 @@ namespace SeedLang.Visualization {
     Upvalue,
   }
 
-  public enum LValueType {
-    ElementOfContainer,
-    Variable,
-  }
-
-  public enum RValueType {
-    ElementOfContainer,
-    TemporaryValue,
-    Variable,
-  }
-
   // The LValue class. It could be a variable or an element of containers. The Keys field is null if
   // it's a variable.
   public class LValue {
-    public LValueType Type { get; }
+    public bool IsElement => !IsVariable;
+    public bool IsVariable => Keys is null;
+
     public Variable Variable { get; }
     public IReadOnlyList<Value> Keys { get; }
 
     public LValue(Variable variable, IReadOnlyList<Value> keys) {
-      Type = LValueType.ElementOfContainer;
       Variable = variable;
       Keys = keys;
     }
 
     public LValue(Variable variable) {
-      Type = LValueType.Variable;
       Variable = variable;
       Keys = null;
     }
 
     public override string ToString() {
-      return Type switch {
-        LValueType.ElementOfContainer => $"{Variable}[{string.Join("][", Keys)}]",
-        LValueType.Variable => $"{Variable}",
-        _ => throw new NotImplementedException($"Unsupported LValue type: {Type}"),
-      };
+      return IsElement ? $"{Variable}[{string.Join("][", Keys)}]" : $"{Variable}";
     }
   }
 
   // The RValue class. It could be a variable, an element of containers or a temporary value. The
-  // Keys field is null if it's a variable. The Variable and Keys field is null if it's a temporary
-  // value.
+  // Keys field is null if it's a variable. The Variable and Keys fields are null if it's a
+  // temporary value.
   public class RValue {
-    public RValueType Type { get; }
+    public bool IsElement => !(Variable is null) && !(Keys is null);
+    public bool IsTemporary => Variable is null && Keys is null;
+    public bool IsVariable => !(Variable is null) && Keys is null;
+
     public Variable Variable { get; }
     public IReadOnlyList<Value> Keys { get; }
     public Value Value { get; }
 
     public RValue(Variable variable, IReadOnlyList<Value> keys, Value value) {
-      Type = RValueType.ElementOfContainer;
       Variable = variable;
       Keys = keys;
       Value = value;
     }
 
     public RValue(Value value) {
-      Type = RValueType.TemporaryValue;
       Variable = null;
       Keys = null;
       Value = value;
     }
 
     public RValue(Variable variable, Value value) {
-      Type = RValueType.Variable;
       Variable = variable;
       Keys = null;
       Value = value;
     }
 
     public override string ToString() {
-      return Type switch {
-        RValueType.ElementOfContainer => $"{Variable}[{string.Join("][", Keys)}] {Value}",
-        RValueType.TemporaryValue => $"{Value}",
-        RValueType.Variable => $"{Variable} {Value}",
-        _ => throw new NotImplementedException($"Unsupported LValue type: {Type}."),
-      };
+      return IsElement ? $"{Variable}[{string.Join("][", Keys)}] {Value}" :
+                         (IsTemporary ? $"{Value}" : $"{Variable} {Value}");
     }
   }
 

--- a/csharp/src/SeedLang/Visualization/EventData.cs
+++ b/csharp/src/SeedLang/Visualization/EventData.cs
@@ -25,19 +25,23 @@ namespace SeedLang.Visualization {
 
   public class Operand {
     public bool IsVariable => !(Variable is null);
-    public bool IsValue => !(Value is null);
 
     public Variable Variable { get; }
     public Value Value { get; }
 
-    public Operand(Variable variable) {
+    public Operand(Variable variable, Value value) {
       Variable = variable;
-      Value = null;
+      Value = value;
     }
 
     public Operand(Value value) {
       Variable = null;
       Value = value;
+    }
+
+    public override string ToString() {
+      string variableString = IsVariable ? $"{Variable} " : "";
+      return $"{variableString}{Value}";
     }
   }
 
@@ -55,7 +59,13 @@ namespace SeedLang.Visualization {
     }
 
     public override string ToString() {
-      return "";
+      var sb = new StringBuilder();
+      sb.Append($"{Name}:{Type}");
+      if (IsElementOfContainer) {
+        var keys = string.Join("][", Keys);
+        sb.Append($"[{keys}]");
+      }
+      return sb.ToString();
     }
   }
 

--- a/csharp/src/SeedLang/Visualization/EventData.cs
+++ b/csharp/src/SeedLang/Visualization/EventData.cs
@@ -1,0 +1,86 @@
+// Copyright 2021-2022 The SeedV Lab.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace SeedLang.Visualization {
+  public enum VariableType {
+    Global,
+    Local,
+    Upvalue,
+  }
+
+  public class Operand {
+    public bool IsVariable => !(Variable is null);
+    public bool IsValue => !(Value is null);
+
+    public Variable Variable { get; }
+    public Value Value { get; }
+
+    public Operand(Variable variable) {
+      Variable = variable;
+      Value = null;
+    }
+
+    public Operand(Value value) {
+      Variable = null;
+      Value = value;
+    }
+  }
+
+  public class Variable {
+    public bool IsElementOfContainer => Keys.Count > 0;
+
+    public string Name { get; }
+    public VariableType Type { get; }
+    public IReadOnlyList<Value> Keys { get; }
+
+    public Variable(string name, VariableType type, IReadOnlyList<Value> keys) {
+      Name = name;
+      Type = type;
+      Keys = keys;
+    }
+
+    public override string ToString() {
+      return "";
+    }
+  }
+
+  public class VTagInfo {
+    public string Name { get; }
+    public IReadOnlyList<string> Args { get; }
+    public IReadOnlyList<Value> Values { get; }
+
+    public VTagInfo(string name, IReadOnlyList<string> args, IReadOnlyList<Value> values) {
+      Debug.Assert(args.Count == values.Count);
+      Name = name;
+      Args = args;
+      Values = values;
+    }
+
+    public override string ToString() {
+      var sb = new StringBuilder();
+      sb.Append(Name);
+      sb.Append('(');
+      for (int i = 0; i < Args.Count; i++) {
+        sb.Append(i > 0 ? ", " : "");
+        sb.Append($"{Args[i]}: {Values[i]}");
+      }
+      sb.Append(')');
+      return sb.ToString();
+    }
+  }
+}

--- a/csharp/src/SeedLang/Visualization/Events.cs
+++ b/csharp/src/SeedLang/Visualization/Events.cs
@@ -42,29 +42,18 @@ namespace SeedLang.Visualization {
       }
 
       public override string ToString() {
-        var sb = new StringBuilder();
-        sb.Append($"{Range} ");
-        if (Variable.IsElementOfContainer) {
-          sb.Append('(');
-        }
-        sb.Append($"{Variable.Name}: {Variable.Type}");
-        if (Variable.IsElementOfContainer) {
-          var keys = string.Join("][", Variable.Keys);
-          sb.Append($")[{keys}]");
-        }
-        sb.Append($" = {Value}");
-        return sb.ToString();
+        return $"{Range} {Variable} = {Value}";
       }
     }
 
     // An event which is triggered when a binary expression is evaluated.
     public class Binary : AbstractEvent {
-      public Value Left { get; }
+      public Operand Left { get; }
       public BinaryOperator Op { get; }
-      public Value Right { get; }
+      public Operand Right { get; }
       public Value Result { get; }
 
-      public Binary(Value left, BinaryOperator op, Value right, Value result, TextRange range) :
+      public Binary(Operand left, BinaryOperator op, Operand right, Value result, TextRange range) :
           base(range) {
         Left = left;
         Op = op;
@@ -174,7 +163,7 @@ namespace SeedLang.Visualization {
       }
 
       public override string ToString() {
-        return $"{Range} VariableDefined: {Name}: {Type}";
+        return $"{Range} VariableDefined: {Name} ({Type})";
       }
     }
 
@@ -189,7 +178,7 @@ namespace SeedLang.Visualization {
       }
 
       public override string ToString() {
-        return $"{Range} VariableDeleted: {Name}: {Type}";
+        return $"{Range} VariableDeleted: {Name} ({Type})";
       }
     }
 

--- a/csharp/src/SeedLang/Visualization/Events.cs
+++ b/csharp/src/SeedLang/Visualization/Events.cs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text;
 using SeedLang.Common;
 using SeedLang.Runtime;
 
@@ -71,28 +69,21 @@ namespace SeedLang.Visualization {
     // The count of values is as same as Ops. But not all the expressions are evaluated due to short
     // circuit. The values without evaluated are filled as null.
     public class Comparison : AbstractEvent {
-      public Value First { get; }
-      public IReadOnlyList<ComparisonOperator> Ops { get; }
-      public IReadOnlyList<Value> Values { get; }
+      public Operand Left { get; }
+      public ComparisonOperator Op { get; }
+      public Operand Right { get; }
       public Value Result { get; }
 
-      public Comparison(Value first, IReadOnlyList<ComparisonOperator> ops,
-                        IReadOnlyList<Value> values, Value result, TextRange range) : base(range) {
-        Debug.Assert(ops.Count > 0 && ops.Count == values.Count);
-        First = first;
-        Values = values;
-        Ops = ops;
+      public Comparison(Operand left, ComparisonOperator op, Operand right, Value result,
+                        TextRange range) : base(range) {
+        Left = left;
+        Op = op;
+        Right = right;
         Result = result;
       }
 
       public override string ToString() {
-        var sb = new StringBuilder();
-        sb.Append($"{Range} {First} ");
-        for (int i = 0; i < Ops.Count; ++i) {
-          sb.Append($"{Ops[i]} {Values[i]} ");
-        }
-        sb.Append($"= {Result}");
-        return sb.ToString();
+        return $"{Range} {Left} {Op} {Right} = {Result}";
       }
     }
 

--- a/csharp/src/SeedLang/Visualization/Events.cs
+++ b/csharp/src/SeedLang/Visualization/Events.cs
@@ -28,8 +28,8 @@ namespace SeedLang.Visualization {
   }
 
   public static class Event {
-    // An event which is triggered when a value is assigned to a variable or an element of a
-    // container.
+    // An event which is triggered when a value is assigned to a variable or an element of
+    // containers.
     public class Assignment : AbstractEvent {
       public Variable Variable { get; }
       public Value Value { get; }
@@ -65,9 +65,6 @@ namespace SeedLang.Visualization {
     }
 
     // An event which is triggered when a comparison expression is evaluated.
-    //
-    // The count of values is as same as Ops. But not all the expressions are evaluated due to short
-    // circuit. The values without evaluated are filled as null.
     public class Comparison : AbstractEvent {
       public Operand Left { get; }
       public ComparisonOperator Op { get; }
@@ -123,23 +120,6 @@ namespace SeedLang.Visualization {
 
       public override string ToString() {
         return $"{Range} SingleStep";
-      }
-    }
-
-    // An event which is triggered when an unary expression is executed.
-    public class Unary : AbstractEvent {
-      public UnaryOperator Op { get; }
-      public Value Value { get; }
-      public Value Result { get; }
-
-      public Unary(UnaryOperator op, Value value, Value result, TextRange range) : base(range) {
-        Op = op;
-        Value = value;
-        Result = result;
-      }
-
-      public override string ToString() {
-        return $"{Range} {Op} {Value} = {Result}";
       }
     }
 

--- a/csharp/src/SeedLang/Visualization/Events.cs
+++ b/csharp/src/SeedLang/Visualization/Events.cs
@@ -31,27 +31,27 @@ namespace SeedLang.Visualization {
     // An event which is triggered when a value is assigned to a variable or an element of
     // containers.
     public class Assignment : AbstractEvent {
-      public Variable Variable { get; }
-      public Value Value { get; }
+      public LValue Target { get; }
+      public RValue Value { get; }
 
-      public Assignment(Variable variable, Value value, TextRange range) : base(range) {
-        Variable = variable;
+      public Assignment(LValue target, RValue value, TextRange range) : base(range) {
+        Target = target;
         Value = value;
       }
 
       public override string ToString() {
-        return $"{Range} {Variable} = {Value}";
+        return $"{Range} {Target} = {Value}";
       }
     }
 
     // An event which is triggered when a binary expression is evaluated.
     public class Binary : AbstractEvent {
-      public Operand Left { get; }
+      public RValue Left { get; }
       public BinaryOperator Op { get; }
-      public Operand Right { get; }
+      public RValue Right { get; }
       public Value Result { get; }
 
-      public Binary(Operand left, BinaryOperator op, Operand right, Value result, TextRange range) :
+      public Binary(RValue left, BinaryOperator op, RValue right, Value result, TextRange range) :
           base(range) {
         Left = left;
         Op = op;
@@ -66,12 +66,12 @@ namespace SeedLang.Visualization {
 
     // An event which is triggered when a comparison expression is evaluated.
     public class Comparison : AbstractEvent {
-      public Operand Left { get; }
+      public RValue Left { get; }
       public ComparisonOperator Op { get; }
-      public Operand Right { get; }
+      public RValue Right { get; }
       public Value Result { get; }
 
-      public Comparison(Operand left, ComparisonOperator op, Operand right, Value result,
+      public Comparison(RValue left, ComparisonOperator op, RValue right, Value result,
                         TextRange range) : base(range) {
         Left = left;
         Op = op;

--- a/csharp/src/SeedLang/Visualization/VisualizerCenter.cs
+++ b/csharp/src/SeedLang/Visualization/VisualizerCenter.cs
@@ -109,6 +109,7 @@ namespace SeedLang.Visualization {
 
     private void EnableVariableTrackingForVariableVisualizers<Visualizer>(Visualizer visualizer) {
       if (visualizer is IVisualizer<Event.Assignment> ||
+          visualizer is IVisualizer<Event.Binary> ||
           visualizer is IVisualizer<Event.VariableDefined> ||
           visualizer is IVisualizer<Event.VariableDeleted>) {
         IsVariableTrackingEnabled = true;

--- a/csharp/src/SeedLang/Visualization/VisualizerCenter.cs
+++ b/csharp/src/SeedLang/Visualization/VisualizerCenter.cs
@@ -110,6 +110,7 @@ namespace SeedLang.Visualization {
     private void EnableVariableTrackingForVariableVisualizers<Visualizer>(Visualizer visualizer) {
       if (visualizer is IVisualizer<Event.Assignment> ||
           visualizer is IVisualizer<Event.Binary> ||
+          visualizer is IVisualizer<Event.Comparison> ||
           visualizer is IVisualizer<Event.VariableDefined> ||
           visualizer is IVisualizer<Event.VariableDeleted>) {
         IsVariableTrackingEnabled = true;

--- a/csharp/src/SeedLang/Visualization/VisualizerCenter.cs
+++ b/csharp/src/SeedLang/Visualization/VisualizerCenter.cs
@@ -108,7 +108,7 @@ namespace SeedLang.Visualization {
     }
 
     private void EnableVariableTrackingForVariableVisualizers<Visualizer>(Visualizer visualizer) {
-      if (visualizer is IVisualizer<Event.SubscriptAssignment> ||
+      if (visualizer is IVisualizer<Event.Assignment> ||
           visualizer is IVisualizer<Event.VariableDefined> ||
           visualizer is IVisualizer<Event.VariableDeleted>) {
         IsVariableTrackingEnabled = true;

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
@@ -67,49 +67,50 @@ namespace SeedLang.Interpreter.Tests {
     [Fact]
     public void TestComparison() {
       string source = @"
-a = 1
-b = 2
-a < b < 3
+1 < 2 > 3
 ";
       string expected = (
         $"Function <main>\n" +
-        $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 2, Col 0]\n" +
-        $"  2    LOADK     0 -1             ; 1                 [Ln 2, Col 4 - Ln 2, Col 4]\n" +
-        $"  3    SETGLOB   0 {_firstGlob}" +
-        $"                                  [Ln 2, Col 0 - Ln 2, Col 4]\n" +
-        $"  4    VISNOTIFY 0 1                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
-        $"  5    LOADK     0 -2             ; 2                 [Ln 3, Col 4 - Ln 3, Col 4]\n" +
-        $"  6    SETGLOB   0 {_firstGlob + 1}" +
-        $"                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
-        $"  7    GETGLOB   0 {_printValFunc}" +
-        $"                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  8    GETGLOB   2 {_firstGlob}" +
-        $"                                  [Ln 4, Col 0 - Ln 4, Col 0]\n" +
-        $"  9    VISNOTIFY 0 2                                  [Ln 4, Col 0 - Ln 4, Col 0]\n" +
-        $"  10   GETGLOB   3 {_firstGlob + 1}" +
-        $"                                  [Ln 4, Col 4 - Ln 4, Col 4]\n" +
-        $"  11   VISNOTIFY 0 3                                  [Ln 4, Col 4 - Ln 4, Col 4]\n" +
-        $"  12   LT        1 2 3                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  13   JMP       0 7              ; to 21             [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  14   VISNOTIFY 0 4                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  15   GETGLOB   2 {_firstGlob + 1}" +
-        $"                                  [Ln 4, Col 4 - Ln 4, Col 4]\n" +
-        $"  16   VISNOTIFY 0 5                                  [Ln 4, Col 4 - Ln 4, Col 4]\n" +
-        $"  17   LT        1 2 -3           ; 3                 [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  18   JMP       0 2              ; to 21             [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  19   VISNOTIFY 0 6                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  20   LOADBOOL  1 1 1                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  21   LOADBOOL  1 0 0                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  22   CALL      0 1 0                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  23   HALT      1 0                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  1    GETGLOB   0 {_printValFunc}" +
+        $"                                  [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  2    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  3    LT        1 -1 -2          ; 1 2               [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  4    JMP       0 4              ; to 9              [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  5    VISNOTIFY 0 1                                  [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  6    LE        0 -2 -3          ; 2 3               [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  7    JMP       0 1              ; to 9              [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  8    LOADBOOL  1 1 1                                [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  9    LOADBOOL  1 0 0                                [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  10   CALL      0 1 0                                [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  11   HALT      1 0                                  [Ln 2, Col 0 - Ln 2, Col 8]\n" +
         $"Notifications\n" +
-        $"  0    Notification.VariableDefined: 'a' Global 7\n" +
-        $"  1    Notification.VariableDefined: 'b' Global 8\n" +
-        $"  2    Notification.GlobalLoaded: 2 'a'\n" +
-        $"  3    Notification.GlobalLoaded: 3 'b'\n" +
-        $"  4    Notification.Comparison: 2 Less 3 0\n" +
-        $"  5    Notification.GlobalLoaded: 2 'b'\n" +
-        $"  6    Notification.Comparison: 2 Less 252 0\n"
+        $"  0    Notification.Comparison: 250 Less 251\n" +
+        $"  1    Notification.Comparison: 251 Greater 252\n"
+      ).Replace("\n", Environment.NewLine);
+      TestCompiler(source, expected, new Type[] { typeof(Event.Comparison) }, RunMode.Interactive);
+    }
+
+    [Fact]
+    public void TestIfComparison() {
+      string source = @"
+if 1 <= 2 >= 3:
+  pass
+else:
+  pass
+";
+      string expected = (
+        $"Function <main>\n" +
+        $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 3 - Ln 2, Col 13]\n" +
+        $"  2    LE        1 -1 -2          ; 1 2               [Ln 2, Col 3 - Ln 2, Col 13]\n" +
+        $"  3    JMP       0 4              ; to 8              [Ln 2, Col 3 - Ln 2, Col 13]\n" +
+        $"  4    VISNOTIFY 0 1                                  [Ln 2, Col 3 - Ln 2, Col 13]\n" +
+        $"  5    LT        0 -2 -3          ; 2 3               [Ln 2, Col 3 - Ln 2, Col 13]\n" +
+        $"  6    JMP       0 1              ; to 8              [Ln 2, Col 3 - Ln 2, Col 13]\n" +
+        $"  7    JMP       0 0              ; to 8              [Ln 2, Col 0 - Ln 5, Col 5]\n" +
+        $"  8    HALT      1 0                                  [Ln 5, Col 2 - Ln 5, Col 5]\n" +
+        $"Notifications\n" +
+        $"  0    Notification.Comparison: 250 LessEqual 251\n" +
+        $"  1    Notification.Comparison: 251 GreaterEqual 252\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] { typeof(Event.Comparison) }, RunMode.Interactive);
     }

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
@@ -40,49 +40,60 @@ for i in range(2):
       string expected = (
         $"Function <main>\n" +
         $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 2, Col 0]\n" +
-        $"  2    LOADK     1 -1             ; 1                 [Ln 2, Col 5 - Ln 2, Col 5]\n" +
-        $"  3    LOADK     2 -2             ; 2                 [Ln 2, Col 8 - Ln 2, Col 8]\n" +
-        $"  4    NEWLIST   0 1 2                                [Ln 2, Col 4 - Ln 2, Col 9]\n" +
-        $"  5    VISNOTIFY 0 1                                  [Ln 2, Col 4 - Ln 2, Col 9]\n" +
-        $"  6    SETGLOB   0 {_firstGlob}" +
+        $"  2    VISNOTIFY 0 1                                  [Ln 2, Col 4 - Ln 2, Col 9]\n" +
+        $"  3    VISNOTIFY 0 2                                  [Ln 2, Col 4 - Ln 2, Col 9]\n" +
+        $"  4    LOADK     1 -1             ; 1                 [Ln 2, Col 5 - Ln 2, Col 5]\n" +
+        $"  5    VISNOTIFY 0 3                                  [Ln 2, Col 4 - Ln 2, Col 9]\n" +
+        $"  6    LOADK     2 -2             ; 2                 [Ln 2, Col 8 - Ln 2, Col 8]\n" +
+        $"  7    NEWLIST   0 1 2                                [Ln 2, Col 4 - Ln 2, Col 9]\n" +
+        $"  8    SETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 2, Col 0 - Ln 2, Col 9]\n" +
-        $"  7    VISNOTIFY 0 2                                  [Ln 2, Col 0 - Ln 2, Col 9]\n" +
-        $"  8    VISNOTIFY 0 3                                  [Ln 3, Col 4 - Ln 3, Col 4]\n" +
-        $"  9    GETGLOB   0 {_rangeFunc}" +
+        $"  9    VISNOTIFY 0 4                                  [Ln 2, Col 0 - Ln 2, Col 9]\n" +
+        $"  10   VISNOTIFY 0 5                                  [Ln 3, Col 4 - Ln 3, Col 4]\n" +
+        $"  11   VISNOTIFY 0 1                                  [Ln 3, Col 0 - Ln 4, Col 9]\n" +
+        $"  12   GETGLOB   0 {_rangeFunc}" +
         $"                                  [Ln 3, Col 9 - Ln 3, Col 13]\n" +
-        $"  10   LOADK     1 -2             ; 2                 [Ln 3, Col 15 - Ln 3, Col 15]\n" +
-        $"  11   CALL      0 1 0                                [Ln 3, Col 9 - Ln 3, Col 16]\n" +
-        $"  12   VISNOTIFY 0 1                                  [Ln 3, Col 9 - Ln 3, Col 16]\n" +
-        $"  13   LOADK     1 -3             ; 0                 [Ln 3, Col 0 - Ln 4, Col 9]\n" +
-        $"  14   LEN       2 0 0                                [Ln 3, Col 0 - Ln 4, Col 9]\n" +
-        $"  15   LOADK     3 -1             ; 1                 [Ln 3, Col 0 - Ln 4, Col 9]\n" +
-        $"  16   FORPREP   1 11             ; to 28             [Ln 3, Col 0 - Ln 4, Col 9]\n" +
-        $"  17   GETELEM   4 0 1                                [Ln 3, Col 0 - Ln 4, Col 9]\n" +
-        $"  18   SETGLOB   4 {_firstGlob + 1}" +
+        $"  13   VISNOTIFY 0 2                                  [Ln 3, Col 15 - Ln 3, Col 15]\n" +
+        $"  14   LOADK     1 -2             ; 2                 [Ln 3, Col 15 - Ln 3, Col 15]\n" +
+        $"  15   CALL      0 1 0                                [Ln 3, Col 9 - Ln 3, Col 16]\n" +
+        $"  16   VISNOTIFY 0 2                                  [Ln 3, Col 0 - Ln 4, Col 9]\n" +
+        $"  17   LOADK     1 -3             ; 0                 [Ln 3, Col 0 - Ln 4, Col 9]\n" +
+        $"  18   VISNOTIFY 0 3                                  [Ln 3, Col 0 - Ln 4, Col 9]\n" +
+        $"  19   LEN       2 0 0                                [Ln 3, Col 0 - Ln 4, Col 9]\n" +
+        $"  20   VISNOTIFY 0 6                                  [Ln 3, Col 0 - Ln 4, Col 9]\n" +
+        $"  21   LOADK     3 -1             ; 1                 [Ln 3, Col 0 - Ln 4, Col 9]\n" +
+        $"  22   FORPREP   1 12             ; to 35             [Ln 3, Col 0 - Ln 4, Col 9]\n" +
+        $"  23   VISNOTIFY 0 7                                  [Ln 3, Col 0 - Ln 4, Col 9]\n" +
+        $"  24   GETELEM   4 0 1                                [Ln 3, Col 0 - Ln 4, Col 9]\n" +
+        $"  25   SETGLOB   4 {_firstGlob + 1}" +
         $"                                  [Ln 3, Col 0 - Ln 4, Col 9]\n" +
-        $"  19   VISNOTIFY 0 4                                  [Ln 3, Col 4 - Ln 3, Col 4]\n" +
-        $"  20   VISNOTIFY 0 5                                  [Ln 3, Col 0 - Ln 4, Col 9]\n" +
-        $"  21   GETGLOB   4 {_firstGlob}" +
+        $"  26   VISNOTIFY 0 8                                  [Ln 3, Col 4 - Ln 3, Col 4]\n" +
+        $"  27   VISNOTIFY 0 7                                  [Ln 4, Col 2 - Ln 4, Col 2]\n" +
+        $"  28   GETGLOB   4 {_firstGlob}" +
         $"                                  [Ln 4, Col 2 - Ln 4, Col 2]\n" +
-        $"  22   VISNOTIFY 0 6                                  [Ln 4, Col 2 - Ln 4, Col 2]\n" +
-        $"  23   GETGLOB   5 {_firstGlob + 1}" +
+        $"  29   VISNOTIFY 0 9                                  [Ln 4, Col 2 - Ln 4, Col 2]\n" +
+        $"  30   VISNOTIFY 0 10                                 [Ln 4, Col 4 - Ln 4, Col 4]\n" +
+        $"  31   GETGLOB   5 {_firstGlob + 1}" +
         $"                                  [Ln 4, Col 4 - Ln 4, Col 4]\n" +
-        $"  24   VISNOTIFY 0 7                                  [Ln 4, Col 4 - Ln 4, Col 4]\n" +
-        $"  25   SETELEM   4 5 -4           ; 5                 [Ln 4, Col 2 - Ln 4, Col 9]\n" +
-        $"  26   VISNOTIFY 0 8                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
-        $"  27   VISNOTIFY 0 5                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
-        $"  28   FORLOOP   1 -12            ; to 17             [Ln 3, Col 0 - Ln 4, Col 9]\n" +
-        $"  29   HALT      1 0                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
+        $"  32   VISNOTIFY 0 11                                 [Ln 4, Col 4 - Ln 4, Col 4]\n" +
+        $"  33   SETELEM   4 5 -4           ; 5                 [Ln 4, Col 2 - Ln 4, Col 9]\n" +
+        $"  34   VISNOTIFY 0 12                                 [Ln 4, Col 2 - Ln 4, Col 9]\n" +
+        $"  35   FORLOOP   1 -13            ; to 23             [Ln 3, Col 0 - Ln 4, Col 9]\n" +
+        $"  36   HALT      1 0                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
         $"Notifications\n" +
         $"  0    Notification.VariableDefined: 'a' Global 7\n" +
-        $"  1    Notification.VariableDeleted: 1\n" +
-        $"  2    Notification.Assignment: 'a' Global 0\n" +
-        $"  3    Notification.VariableDefined: 'i' Global 8\n" +
-        $"  4    Notification.Assignment: 'i' Global 4\n" +
-        $"  5    Notification.VariableDeleted: 4\n" +
-        $"  6    Notification.GlobalLoaded: 4 'a'\n" +
-        $"  7    Notification.GlobalLoaded: 5 'i'\n" +
-        $"  8    Notification.SubscriptAssignment: 4 5 253\n"
+        $"  1    Notification.TempRegisterAllocated: 0\n" +
+        $"  2    Notification.TempRegisterAllocated: 1\n" +
+        $"  3    Notification.TempRegisterAllocated: 2\n" +
+        $"  4    Notification.Assignment: 'a' Global 0\n" +
+        $"  5    Notification.VariableDefined: 'i' Global 8\n" +
+        $"  6    Notification.TempRegisterAllocated: 3\n" +
+        $"  7    Notification.TempRegisterAllocated: 4\n" +
+        $"  8    Notification.Assignment: 'i' Global 4\n" +
+        $"  9    Notification.GlobalLoaded: 4 'a'\n" +
+        $"  10   Notification.TempRegisterAllocated: 5\n" +
+        $"  11   Notification.GlobalLoaded: 5 'i'\n" +
+        $"  12   Notification.SubscriptAssignment: 4 5 253\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] { typeof(Event.Assignment) }, RunMode.Interactive);
     }
@@ -92,14 +103,18 @@ for i in range(2):
       string source = "1 + 2";
       string expected = (
         $"Function <main>\n" +
-        $"  1    GETGLOB   0 {_printValFunc}" +
+        $"  1    VISNOTIFY 0 0                                  [Ln 1, Col 0 - Ln 1, Col 4]\n" +
+        $"  2    GETGLOB   0 {_printValFunc}" +
         $"                                  [Ln 1, Col 0 - Ln 1, Col 4]\n" +
-        $"  2    ADD       1 -1 -2          ; 1 2               [Ln 1, Col 0 - Ln 1, Col 4]\n" +
-        $"  3    VISNOTIFY 0 0                                  [Ln 1, Col 0 - Ln 1, Col 4]\n" +
-        $"  4    CALL      0 1 0                                [Ln 1, Col 0 - Ln 1, Col 4]\n" +
-        $"  5    HALT      1 0                                  [Ln 1, Col 0 - Ln 1, Col 4]\n" +
+        $"  3    VISNOTIFY 0 1                                  [Ln 1, Col 0 - Ln 1, Col 4]\n" +
+        $"  4    ADD       1 -1 -2          ; 1 2               [Ln 1, Col 0 - Ln 1, Col 4]\n" +
+        $"  5    VISNOTIFY 0 2                                  [Ln 1, Col 0 - Ln 1, Col 4]\n" +
+        $"  6    CALL      0 1 0                                [Ln 1, Col 0 - Ln 1, Col 4]\n" +
+        $"  7    HALT      1 0                                  [Ln 1, Col 0 - Ln 1, Col 4]\n" +
         $"Notifications\n" +
-        $"  0    Notification.Binary: 250 Add 251 1\n"
+        $"  0    Notification.TempRegisterAllocated: 0\n" +
+        $"  1    Notification.TempRegisterAllocated: 1\n" +
+        $"  2    Notification.Binary: 250 Add 251 1\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] { typeof(Event.Binary) }, RunMode.Interactive);
     }
@@ -111,21 +126,25 @@ for i in range(2):
 ";
       string expected = (
         $"Function <main>\n" +
-        $"  1    GETGLOB   0 {_printValFunc}" +
+        $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  2    GETGLOB   0 {_printValFunc}" +
         $"                                  [Ln 2, Col 0 - Ln 2, Col 8]\n" +
-        $"  2    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 2, Col 8]\n" +
-        $"  3    LT        1 -1 -2          ; 1 2               [Ln 2, Col 0 - Ln 2, Col 8]\n" +
-        $"  4    JMP       0 4              ; to 9              [Ln 2, Col 0 - Ln 2, Col 8]\n" +
-        $"  5    VISNOTIFY 0 1                                  [Ln 2, Col 0 - Ln 2, Col 8]\n" +
-        $"  6    LE        0 -2 -3          ; 2 3               [Ln 2, Col 0 - Ln 2, Col 8]\n" +
-        $"  7    JMP       0 1              ; to 9              [Ln 2, Col 0 - Ln 2, Col 8]\n" +
-        $"  8    LOADBOOL  1 1 1                                [Ln 2, Col 0 - Ln 2, Col 8]\n" +
-        $"  9    LOADBOOL  1 0 0                                [Ln 2, Col 0 - Ln 2, Col 8]\n" +
-        $"  10   CALL      0 1 0                                [Ln 2, Col 0 - Ln 2, Col 8]\n" +
-        $"  11   HALT      1 0                                  [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  3    VISNOTIFY 0 1                                  [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  4    VISNOTIFY 0 2                                  [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  5    LT        1 -1 -2          ; 1 2               [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  6    JMP       0 4              ; to 11             [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  7    VISNOTIFY 0 3                                  [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  8    LE        0 -2 -3          ; 2 3               [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  9    JMP       0 1              ; to 11             [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  10   LOADBOOL  1 1 1                                [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  11   LOADBOOL  1 0 0                                [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  12   CALL      0 1 0                                [Ln 2, Col 0 - Ln 2, Col 8]\n" +
+        $"  13   HALT      1 0                                  [Ln 2, Col 0 - Ln 2, Col 8]\n" +
         $"Notifications\n" +
-        $"  0    Notification.Comparison: 250 Less 251\n" +
-        $"  1    Notification.Comparison: 251 Greater 252\n"
+        $"  0    Notification.TempRegisterAllocated: 0\n" +
+        $"  1    Notification.TempRegisterAllocated: 1\n" +
+        $"  2    Notification.Comparison: 250 Less 251\n" +
+        $"  3    Notification.Comparison: 251 Greater 252\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] { typeof(Event.Comparison) }, RunMode.Interactive);
     }

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
@@ -65,6 +65,56 @@ namespace SeedLang.Interpreter.Tests {
     }
 
     [Fact]
+    public void TestComparison() {
+      string source = @"
+a = 1
+b = 2
+a < b < 3
+";
+      string expected = (
+        $"Function <main>\n" +
+        $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 2, Col 0]\n" +
+        $"  2    LOADK     0 -1             ; 1                 [Ln 2, Col 4 - Ln 2, Col 4]\n" +
+        $"  3    SETGLOB   0 {_firstGlob}" +
+        $"                                  [Ln 2, Col 0 - Ln 2, Col 4]\n" +
+        $"  4    VISNOTIFY 0 1                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
+        $"  5    LOADK     0 -2             ; 2                 [Ln 3, Col 4 - Ln 3, Col 4]\n" +
+        $"  6    SETGLOB   0 {_firstGlob + 1}" +
+        $"                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
+        $"  7    GETGLOB   0 {_printValFunc}" +
+        $"                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  8    GETGLOB   2 {_firstGlob}" +
+        $"                                  [Ln 4, Col 0 - Ln 4, Col 0]\n" +
+        $"  9    VISNOTIFY 0 2                                  [Ln 4, Col 0 - Ln 4, Col 0]\n" +
+        $"  10   GETGLOB   3 {_firstGlob + 1}" +
+        $"                                  [Ln 4, Col 4 - Ln 4, Col 4]\n" +
+        $"  11   VISNOTIFY 0 3                                  [Ln 4, Col 4 - Ln 4, Col 4]\n" +
+        $"  12   LT        1 2 3                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  13   JMP       0 7              ; to 21             [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  14   VISNOTIFY 0 4                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  15   GETGLOB   2 {_firstGlob + 1}" +
+        $"                                  [Ln 4, Col 4 - Ln 4, Col 4]\n" +
+        $"  16   VISNOTIFY 0 5                                  [Ln 4, Col 4 - Ln 4, Col 4]\n" +
+        $"  17   LT        1 2 -3           ; 3                 [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  18   JMP       0 2              ; to 21             [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  19   VISNOTIFY 0 6                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  20   LOADBOOL  1 1 1                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  21   LOADBOOL  1 0 0                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  22   CALL      0 1 0                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  23   HALT      1 0                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"Notifications\n" +
+        $"  0    Notification.VariableDefined: 'a' Global 7\n" +
+        $"  1    Notification.VariableDefined: 'b' Global 8\n" +
+        $"  2    Notification.GlobalLoaded: 2 'a'\n" +
+        $"  3    Notification.GlobalLoaded: 3 'b'\n" +
+        $"  4    Notification.Comparison: 2 Less 3 0\n" +
+        $"  5    Notification.GlobalLoaded: 2 'b'\n" +
+        $"  6    Notification.Comparison: 2 Less 252 0\n"
+      ).Replace("\n", Environment.NewLine);
+      TestCompiler(source, expected, new Type[] { typeof(Event.Comparison) }, RunMode.Interactive);
+    }
+
+    [Fact]
     public void TestFuncCall() {
       string source = @"
 def add(a, b):

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
@@ -73,30 +73,38 @@ add(1, 2)
 ";
       string expected = (
         $"Function <main>\n" +
-        $"  1    LOADK     0 -1             ; Func <add>        [Ln 2, Col 0 - Ln 3, Col 13]\n" +
-        $"  2    SETGLOB   0 {_firstGlob}" +
+        $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 3, Col 13]\n" +
+        $"  2    LOADK     0 -1             ; Func <add>        [Ln 2, Col 0 - Ln 3, Col 13]\n" +
+        $"  3    SETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 2, Col 0 - Ln 3, Col 13]\n" +
-        $"  3    GETGLOB   0 {_printValFunc}" +
+        $"  4    GETGLOB   0 {_printValFunc}" +
         $"                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  4    GETGLOB   1 {_firstGlob}" +
+        $"  5    GETGLOB   1 {_firstGlob}" +
         $"                                  [Ln 4, Col 0 - Ln 4, Col 2]\n" +
-        $"  5    LOADK     2 -2             ; 1                 [Ln 4, Col 4 - Ln 4, Col 4]\n" +
-        $"  6    LOADK     3 -3             ; 2                 [Ln 4, Col 7 - Ln 4, Col 7]\n" +
-        $"  7    VISNOTIFY 0 0                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  8    CALL      1 2 0                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  9    VISNOTIFY 1 0                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  10   CALL      0 1 0                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  11   HALT      1 0                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  6    LOADK     2 -2             ; 1                 [Ln 4, Col 4 - Ln 4, Col 4]\n" +
+        $"  7    LOADK     3 -3             ; 2                 [Ln 4, Col 7 - Ln 4, Col 7]\n" +
+        $"  8    VISNOTIFY 0 1                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  9    CALL      1 2 0                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  10   VISNOTIFY 1 1                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  11   VISNOTIFY 0 2                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  12   CALL      0 1 0                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  13   HALT      1 0                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
         $"Notifications\n" +
-        $"  0    Notification.Function: add 1 2\n" +
+        $"  0    Notification.VariableDefined: 'add' Global 7\n" +
+        $"  1    Notification.Function: add 1 2\n" +
+        $"  2    Notification.VariableDeleted: 0\n" +
         $"\n" +
         $"Function <add>\n" +
-        $"  1    ADD       2 0 1                                [Ln 3, Col 9 - Ln 3, Col 13]\n" +
-        $"  2    VISNOTIFY 0 0                                  [Ln 3, Col 9 - Ln 3, Col 13]\n" +
-        $"  3    RETURN    2 1                                  [Ln 3, Col 2 - Ln 3, Col 13]\n" +
-        $"  4    RETURN    0 0                                  [Ln 3, Col 2 - Ln 3, Col 13]\n" +
+        $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 8 - Ln 2, Col 8]\n" +
+        $"  2    VISNOTIFY 0 1                                  [Ln 2, Col 11 - Ln 2, Col 11]\n" +
+        $"  3    ADD       2 0 1                                [Ln 3, Col 9 - Ln 3, Col 13]\n" +
+        $"  4    VISNOTIFY 0 2                                  [Ln 3, Col 9 - Ln 3, Col 13]\n" +
+        $"  5    RETURN    2 1                                  [Ln 3, Col 2 - Ln 3, Col 13]\n" +
+        $"  6    RETURN    0 0                                  [Ln 3, Col 2 - Ln 3, Col 13]\n" +
         $"Notifications\n" +
-        $"  0    Notification.Binary: 0 Add 1 2\n"
+        $"  0    Notification.VariableDefined: 'add.a' Local 0\n" +
+        $"  1    Notification.VariableDefined: 'add.b' Local 1\n" +
+        $"  2    Notification.Binary: 0 Add 1 2\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] {
         typeof(Event.Binary),

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
@@ -449,23 +449,6 @@ a[0][1] = 1
     }
 
     [Fact]
-    public void TestUnary() {
-      string source = "-1";
-      string expected = (
-        $"Function <main>\n" +
-        $"  1    GETGLOB   0 {_printValFunc}" +
-        $"                                  [Ln 1, Col 0 - Ln 1, Col 1]\n" +
-        $"  2    UNM       1 -1             ; 1                 [Ln 1, Col 0 - Ln 1, Col 1]\n" +
-        $"  3    VISNOTIFY 0 0                                  [Ln 1, Col 0 - Ln 1, Col 1]\n" +
-        $"  4    CALL      0 1 0                                [Ln 1, Col 0 - Ln 1, Col 1]\n" +
-        $"  5    HALT      1 0                                  [Ln 1, Col 0 - Ln 1, Col 1]\n" +
-        $"Notifications\n" +
-        $"  0    Notification.Unary: Negative 250 1\n"
-      ).Replace("\n", Environment.NewLine);
-      TestCompiler(source, expected, new Type[] { typeof(Event.Unary) }, RunMode.Interactive);
-    }
-
-    [Fact]
     public void TestVariables() {
       string source = @"
 def add(a, b):

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
@@ -34,13 +34,15 @@ namespace SeedLang.Interpreter.Tests {
       string source = "name = 1";
       string expected = (
         $"Function <main>\n" +
-        $"  1    LOADK     0 -1             ; 1                 [Ln 1, Col 7 - Ln 1, Col 7]\n" +
-        $"  2    SETGLOB   0 {_firstGlob}" +
+        $"  1    VISNOTIFY 0 0                                  [Ln 1, Col 0 - Ln 1, Col 3]\n" +
+        $"  2    LOADK     0 -1             ; 1                 [Ln 1, Col 7 - Ln 1, Col 7]\n" +
+        $"  3    SETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 1, Col 0 - Ln 1, Col 7]\n" +
-        $"  3    VISNOTIFY 0 0                                  [Ln 1, Col 0 - Ln 1, Col 7]\n" +
-        $"  4    HALT      1 0                                  [Ln 1, Col 0 - Ln 1, Col 7]\n" +
+        $"  4    VISNOTIFY 0 1                                  [Ln 1, Col 0 - Ln 1, Col 7]\n" +
+        $"  5    HALT      1 0                                  [Ln 1, Col 0 - Ln 1, Col 7]\n" +
         $"Notifications\n" +
-        $"  0    Notification.Assignment: 'name': Global 0\n"
+        $"  0    Notification.VariableDefined: 'name' Global 7\n" +
+        $"  1    Notification.Assignment: 'name' Global 0\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] { typeof(Event.Assignment) }, RunMode.Interactive);
     }
@@ -285,8 +287,7 @@ x = 1
         $"Notifications\n" +
         $"  0    Notification.SubscriptAssignment: 0 250 250\n"
       ).Replace("\n", Environment.NewLine);
-      TestCompiler(source, expected, new Type[] { typeof(Event.SubscriptAssignment) },
-                   RunMode.Interactive);
+      TestCompiler(source, expected, new Type[] { typeof(Event.Assignment) }, RunMode.Interactive);
     }
 
     [Fact]
@@ -303,19 +304,20 @@ a[1] = 1
         $"  4    NEWLIST   0 1 2                                [Ln 2, Col 4 - Ln 2, Col 9]\n" +
         $"  5    SETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 2, Col 0 - Ln 2, Col 9]\n" +
-        $"  6    GETGLOB   0 {_firstGlob}" +
+        $"  6    VISNOTIFY 0 1                                  [Ln 2, Col 0 - Ln 2, Col 9]\n" +
+        $"  7    GETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
-        $"  7    VISNOTIFY 0 1                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
-        $"  8    SETELEM   0 -1 -1          ; 1 1               [Ln 3, Col 0 - Ln 3, Col 7]\n" +
-        $"  9    VISNOTIFY 0 2                                  [Ln 3, Col 0 - Ln 3, Col 7]\n" +
-        $"  10   HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 7]\n" +
+        $"  8    VISNOTIFY 0 2                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
+        $"  9    SETELEM   0 -1 -1          ; 1 1               [Ln 3, Col 0 - Ln 3, Col 7]\n" +
+        $"  10   VISNOTIFY 0 3                                  [Ln 3, Col 0 - Ln 3, Col 7]\n" +
+        $"  11   HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 7]\n" +
         $"Notifications\n" +
         $"  0    Notification.VariableDefined: 'a' Global 7\n" +
-        $"  1    Notification.GlobalLoaded: 0 'a'\n" +
-        $"  2    Notification.SubscriptAssignment: 0 250 250\n"
+        $"  1    Notification.Assignment: 'a' Global 0\n" +
+        $"  2    Notification.GlobalLoaded: 0 'a'\n" +
+        $"  3    Notification.SubscriptAssignment: 0 250 250\n"
       ).Replace("\n", Environment.NewLine);
-      TestCompiler(source, expected, new Type[] { typeof(Event.SubscriptAssignment) },
-                   RunMode.Interactive);
+      TestCompiler(source, expected, new Type[] { typeof(Event.Assignment) }, RunMode.Interactive);
     }
 
     [Fact]
@@ -340,15 +342,51 @@ def func():
         $"  2    LOADK     1 -1             ; 1                 [Ln 3, Col 7 - Ln 3, Col 7]\n" +
         $"  3    LOADK     2 -2             ; 2                 [Ln 3, Col 10 - Ln 3, Col 10]\n" +
         $"  4    NEWLIST   0 1 2                                [Ln 3, Col 6 - Ln 3, Col 11]\n" +
-        $"  5    SETELEM   0 -1 -1          ; 1 1               [Ln 4, Col 2 - Ln 4, Col 9]\n" +
-        $"  6    VISNOTIFY 0 1                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
-        $"  7    RETURN    0 0                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
+        $"  5    VISNOTIFY 0 1                                  [Ln 3, Col 2 - Ln 3, Col 11]\n" +
+        $"  6    SETELEM   0 -1 -1          ; 1 1               [Ln 4, Col 2 - Ln 4, Col 9]\n" +
+        $"  7    VISNOTIFY 0 2                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
+        $"  8    RETURN    0 0                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
         $"Notifications\n" +
         $"  0    Notification.VariableDefined: 'func.a' Local 0\n" +
-        $"  1    Notification.SubscriptAssignment: 0 250 250\n"
+        $"  1    Notification.Assignment: 'func.a' Local 0\n" +
+        $"  2    Notification.SubscriptAssignment: 0 250 250\n"
       ).Replace("\n", Environment.NewLine);
-      TestCompiler(source, expected, new Type[] { typeof(Event.SubscriptAssignment) },
-                   RunMode.Interactive);
+      TestCompiler(source, expected, new Type[] { typeof(Event.Assignment) }, RunMode.Interactive);
+    }
+
+    [Fact]
+    public void TestSubscriptAssignMultipleKeys() {
+      string source = @"
+a = [[1, 2], 3]
+a[0][1] = 1
+";
+      string expected = (
+        $"Function <main>\n" +
+        $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 2, Col 0]\n" +
+        $"  2    LOADK     2 -1             ; 1                 [Ln 2, Col 6 - Ln 2, Col 6]\n" +
+        $"  3    LOADK     3 -2             ; 2                 [Ln 2, Col 9 - Ln 2, Col 9]\n" +
+        $"  4    NEWLIST   1 2 2                                [Ln 2, Col 5 - Ln 2, Col 10]\n" +
+        $"  5    LOADK     2 -3             ; 3                 [Ln 2, Col 13 - Ln 2, Col 13]\n" +
+        $"  6    NEWLIST   0 1 2                                [Ln 2, Col 4 - Ln 2, Col 14]\n" +
+        $"  7    SETGLOB   0 {_firstGlob}" +
+        $"                                  [Ln 2, Col 0 - Ln 2, Col 14]\n" +
+        $"  8    VISNOTIFY 0 1                                  [Ln 2, Col 0 - Ln 2, Col 14]\n" +
+        $"  9    GETGLOB   1 {_firstGlob}" +
+        $"                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
+        $"  10   VISNOTIFY 0 2                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
+        $"  11   GETELEM   0 1 -4           ; 0                 [Ln 3, Col 0 - Ln 3, Col 3]\n" +
+        $"  12   VISNOTIFY 0 3                                  [Ln 3, Col 0 - Ln 3, Col 3]\n" +
+        $"  13   SETELEM   0 -1 -1          ; 1 1               [Ln 3, Col 0 - Ln 3, Col 10]\n" +
+        $"  14   VISNOTIFY 0 4                                  [Ln 3, Col 0 - Ln 3, Col 10]\n" +
+        $"  15   HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 10]\n" +
+        $"Notifications\n" +
+        $"  0    Notification.VariableDefined: 'a' Global 7\n" +
+        $"  1    Notification.Assignment: 'a' Global 0\n" +
+        $"  2    Notification.GlobalLoaded: 1 'a'\n" +
+        $"  3    Notification.ElementLoaded: 0 1 253\n" +
+        $"  4    Notification.SubscriptAssignment: 0 250 250\n"
+      ).Replace("\n", Environment.NewLine);
+      TestCompiler(source, expected, new Type[] { typeof(Event.Assignment) }, RunMode.Interactive);
     }
 
     [Fact]
@@ -489,33 +527,37 @@ x, y = 1, 1 + 2
         $"Function <main>\n" +
         $"  1    ADD       2 -1 -2          ; 1 2               [Ln 2, Col 21 - Ln 2, Col 25]\n" +
         $"  2    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 4, Col 3]\n" +
-        $"  3    LOADK     1 -1             ; 1                 [Ln 3, Col 7 - Ln 3, Col 7]\n" +
-        $"  4    ADD       2 -1 -2          ; 1 2               [Ln 3, Col 10 - Ln 3, Col 14]\n" +
-        $"  5    VISNOTIFY 0 1                                  [Ln 3, Col 10 - Ln 3, Col 14]\n" +
-        $"  6    NEWTUPLE  0 1 2                                [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  7    LOADK     2 -3             ; 0                 [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  8    GETELEM   1 0 2                                [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  9    SETGLOB   1 {_firstGlob}" +
+        $"  3    VISNOTIFY 0 1                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
+        $"  4    VISNOTIFY 0 2                                  [Ln 3, Col 3 - Ln 3, Col 3]\n" +
+        $"  5    LOADK     1 -1             ; 1                 [Ln 3, Col 7 - Ln 3, Col 7]\n" +
+        $"  6    ADD       2 -1 -2          ; 1 2               [Ln 3, Col 10 - Ln 3, Col 14]\n" +
+        $"  7    VISNOTIFY 0 3                                  [Ln 3, Col 10 - Ln 3, Col 14]\n" +
+        $"  8    NEWTUPLE  0 1 2                                [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  9    LOADK     2 -3             ; 0                 [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  10   GETELEM   1 0 2                                [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  11   SETGLOB   1 {_firstGlob}" +
         $"                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  10   VISNOTIFY 0 2                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  11   LOADK     2 -1             ; 1                 [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  12   GETELEM   1 0 2                                [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  13   SETGLOB   1 {_firstGlob + 1}" +
+        $"  12   VISNOTIFY 0 4                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  13   LOADK     2 -1             ; 1                 [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  14   GETELEM   1 0 2                                [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  15   SETGLOB   1 {_firstGlob + 1}" +
         $"                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  14   VISNOTIFY 0 3                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  15   GETGLOB   0 {_firstGlob}" +
+        $"  16   VISNOTIFY 0 5                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  17   GETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 2, Col 12 - Ln 2, Col 12]\n" +
-        $"  16   GETGLOB   1 {_firstGlob + 1}" +
+        $"  18   GETGLOB   1 {_firstGlob + 1}" +
         $"                                  [Ln 2, Col 18 - Ln 2, Col 18]\n" +
-        $"  17   ADD       2 -1 -2          ; 1 2               [Ln 2, Col 21 - Ln 2, Col 25]\n" +
-        $"  18   VISNOTIFY 1 4                                  [Ln 2, Col 0 - Ln 4, Col 3]\n" +
-        $"  19   HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  19   ADD       2 -1 -2          ; 1 2               [Ln 2, Col 21 - Ln 2, Col 25]\n" +
+        $"  20   VISNOTIFY 1 6                                  [Ln 2, Col 0 - Ln 4, Col 3]\n" +
+        $"  21   HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
         $"Notifications\n" +
         $"  0    Notification.VTag: Assign(x: null, 1: 250, y: null, 1+2: 2)\n" +
-        $"  1    Notification.Binary: 250 Add 251 2\n" +
-        $"  2    Notification.Assignment: 'x': Global 1\n" +
-        $"  3    Notification.Assignment: 'y': Global 1\n" +
-        $"  4    Notification.VTag: Assign(x: 0, 1: 250, y: 1, 1+2: 2)\n"
+        $"  1    Notification.VariableDefined: 'x' Global {_firstGlob}\n" +
+        $"  2    Notification.VariableDefined: 'y' Global {_firstGlob + 1}\n" +
+        $"  3    Notification.Binary: 250 Add 251 2\n" +
+        $"  4    Notification.Assignment: 'x' Global 1\n" +
+        $"  5    Notification.Assignment: 'y' Global 1\n" +
+        $"  6    Notification.VTag: Assign(x: 0, 1: 250, y: 1, 1+2: 2)\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] {
         typeof(Event.Assignment),

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompileNotificationTests.cs
@@ -184,37 +184,48 @@ add(1, 2)
       string expected = (
         $"Function <main>\n" +
         $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 3, Col 13]\n" +
-        $"  2    LOADK     0 -1             ; Func <add>        [Ln 2, Col 0 - Ln 3, Col 13]\n" +
-        $"  3    SETGLOB   0 {_firstGlob}" +
+        $"  2    VISNOTIFY 0 1                                  [Ln 2, Col 0 - Ln 3, Col 13]\n" +
+        $"  3    LOADK     0 -1             ; Func <add>        [Ln 2, Col 0 - Ln 3, Col 13]\n" +
+        $"  4    SETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 2, Col 0 - Ln 3, Col 13]\n" +
-        $"  4    GETGLOB   0 {_printValFunc}" +
+        $"  5    VISNOTIFY 0 1                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  6    GETGLOB   0 {_printValFunc}" +
         $"                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  5    GETGLOB   1 {_firstGlob}" +
+        $"  7    VISNOTIFY 0 2                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  8    GETGLOB   1 {_firstGlob}" +
         $"                                  [Ln 4, Col 0 - Ln 4, Col 2]\n" +
-        $"  6    LOADK     2 -2             ; 1                 [Ln 4, Col 4 - Ln 4, Col 4]\n" +
-        $"  7    LOADK     3 -3             ; 2                 [Ln 4, Col 7 - Ln 4, Col 7]\n" +
-        $"  8    VISNOTIFY 0 1                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  9    CALL      1 2 0                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  10   VISNOTIFY 1 1                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  11   VISNOTIFY 0 2                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  12   CALL      0 1 0                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
-        $"  13   HALT      1 0                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  9    VISNOTIFY 0 3                                  [Ln 4, Col 4 - Ln 4, Col 4]\n" +
+        $"  10   LOADK     2 -2             ; 1                 [Ln 4, Col 4 - Ln 4, Col 4]\n" +
+        $"  11   VISNOTIFY 0 4                                  [Ln 4, Col 7 - Ln 4, Col 7]\n" +
+        $"  12   LOADK     3 -3             ; 2                 [Ln 4, Col 7 - Ln 4, Col 7]\n" +
+        $"  13   VISNOTIFY 0 5                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  14   CALL      1 2 0                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  15   VISNOTIFY 1 5                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  16   VISNOTIFY 0 6                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  17   CALL      0 1 0                                [Ln 4, Col 0 - Ln 4, Col 8]\n" +
+        $"  18   HALT      1 0                                  [Ln 4, Col 0 - Ln 4, Col 8]\n" +
         $"Notifications\n" +
         $"  0    Notification.VariableDefined: 'add' Global 7\n" +
-        $"  1    Notification.Function: add 1 2\n" +
-        $"  2    Notification.VariableDeleted: 0\n" +
+        $"  1    Notification.TempRegisterAllocated: 0\n" +
+        $"  2    Notification.TempRegisterAllocated: 1\n" +
+        $"  3    Notification.TempRegisterAllocated: 2\n" +
+        $"  4    Notification.TempRegisterAllocated: 3\n" +
+        $"  5    Notification.Function: add 1 2\n" +
+        $"  6    Notification.VariableDeleted: 0\n" +
         $"\n" +
         $"Function <add>\n" +
         $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 8 - Ln 2, Col 8]\n" +
         $"  2    VISNOTIFY 0 1                                  [Ln 2, Col 11 - Ln 2, Col 11]\n" +
-        $"  3    ADD       2 0 1                                [Ln 3, Col 9 - Ln 3, Col 13]\n" +
-        $"  4    VISNOTIFY 0 2                                  [Ln 3, Col 9 - Ln 3, Col 13]\n" +
-        $"  5    RETURN    2 1                                  [Ln 3, Col 2 - Ln 3, Col 13]\n" +
-        $"  6    RETURN    0 0                                  [Ln 3, Col 2 - Ln 3, Col 13]\n" +
+        $"  3    VISNOTIFY 0 2                                  [Ln 3, Col 2 - Ln 3, Col 13]\n" +
+        $"  4    ADD       2 0 1                                [Ln 3, Col 9 - Ln 3, Col 13]\n" +
+        $"  5    VISNOTIFY 0 3                                  [Ln 3, Col 9 - Ln 3, Col 13]\n" +
+        $"  6    RETURN    2 1                                  [Ln 3, Col 2 - Ln 3, Col 13]\n" +
+        $"  7    RETURN    0 0                                  [Ln 3, Col 2 - Ln 3, Col 13]\n" +
         $"Notifications\n" +
         $"  0    Notification.VariableDefined: 'add.a' Local 0\n" +
         $"  1    Notification.VariableDefined: 'add.b' Local 1\n" +
-        $"  2    Notification.Binary: 0 Add 1 2\n"
+        $"  2    Notification.TempRegisterAllocated: 2\n" +
+        $"  3    Notification.Binary: 0 Add 1 2\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] {
         typeof(Event.Binary),
@@ -396,14 +407,20 @@ x = 1
       string source = "[1, 2][1] = 1";
       string expected = (
         $"Function <main>\n" +
-        $"  1    LOADK     1 -1             ; 1                 [Ln 1, Col 1 - Ln 1, Col 1]\n" +
-        $"  2    LOADK     2 -2             ; 2                 [Ln 1, Col 4 - Ln 1, Col 4]\n" +
-        $"  3    NEWLIST   0 1 2                                [Ln 1, Col 0 - Ln 1, Col 5]\n" +
-        $"  4    SETELEM   0 -1 -1          ; 1 1               [Ln 1, Col 0 - Ln 1, Col 12]\n" +
-        $"  5    VISNOTIFY 0 0                                  [Ln 1, Col 0 - Ln 1, Col 12]\n" +
-        $"  6    HALT      1 0                                  [Ln 1, Col 0 - Ln 1, Col 12]\n" +
+        $"  1    VISNOTIFY 0 0                                  [Ln 1, Col 0 - Ln 1, Col 5]\n" +
+        $"  2    VISNOTIFY 0 1                                  [Ln 1, Col 0 - Ln 1, Col 5]\n" +
+        $"  3    LOADK     1 -1             ; 1                 [Ln 1, Col 1 - Ln 1, Col 1]\n" +
+        $"  4    VISNOTIFY 0 2                                  [Ln 1, Col 0 - Ln 1, Col 5]\n" +
+        $"  5    LOADK     2 -2             ; 2                 [Ln 1, Col 4 - Ln 1, Col 4]\n" +
+        $"  6    NEWLIST   0 1 2                                [Ln 1, Col 0 - Ln 1, Col 5]\n" +
+        $"  7    SETELEM   0 -1 -1          ; 1 1               [Ln 1, Col 0 - Ln 1, Col 12]\n" +
+        $"  8    VISNOTIFY 0 3                                  [Ln 1, Col 0 - Ln 1, Col 12]\n" +
+        $"  9    HALT      1 0                                  [Ln 1, Col 0 - Ln 1, Col 12]\n" +
         $"Notifications\n" +
-        $"  0    Notification.SubscriptAssignment: 0 250 250\n"
+        $"  0    Notification.TempRegisterAllocated: 0\n" +
+        $"  1    Notification.TempRegisterAllocated: 1\n" +
+        $"  2    Notification.TempRegisterAllocated: 2\n" +
+        $"  3    Notification.SubscriptAssignment: 0 250 250\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] { typeof(Event.Assignment) }, RunMode.Interactive);
     }
@@ -417,23 +434,30 @@ a[1] = 1
       string expected = (
         $"Function <main>\n" +
         $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 2, Col 0]\n" +
-        $"  2    LOADK     1 -1             ; 1                 [Ln 2, Col 5 - Ln 2, Col 5]\n" +
-        $"  3    LOADK     2 -2             ; 2                 [Ln 2, Col 8 - Ln 2, Col 8]\n" +
-        $"  4    NEWLIST   0 1 2                                [Ln 2, Col 4 - Ln 2, Col 9]\n" +
-        $"  5    SETGLOB   0 {_firstGlob}" +
+        $"  2    VISNOTIFY 0 1                                  [Ln 2, Col 4 - Ln 2, Col 9]\n" +
+        $"  3    VISNOTIFY 0 2                                  [Ln 2, Col 4 - Ln 2, Col 9]\n" +
+        $"  4    LOADK     1 -1             ; 1                 [Ln 2, Col 5 - Ln 2, Col 5]\n" +
+        $"  5    VISNOTIFY 0 3                                  [Ln 2, Col 4 - Ln 2, Col 9]\n" +
+        $"  6    LOADK     2 -2             ; 2                 [Ln 2, Col 8 - Ln 2, Col 8]\n" +
+        $"  7    NEWLIST   0 1 2                                [Ln 2, Col 4 - Ln 2, Col 9]\n" +
+        $"  8    SETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 2, Col 0 - Ln 2, Col 9]\n" +
-        $"  6    VISNOTIFY 0 1                                  [Ln 2, Col 0 - Ln 2, Col 9]\n" +
-        $"  7    GETGLOB   0 {_firstGlob}" +
+        $"  9    VISNOTIFY 0 4                                  [Ln 2, Col 0 - Ln 2, Col 9]\n" +
+        $"  10   VISNOTIFY 0 1                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
+        $"  11   GETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
-        $"  8    VISNOTIFY 0 2                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
-        $"  9    SETELEM   0 -1 -1          ; 1 1               [Ln 3, Col 0 - Ln 3, Col 7]\n" +
-        $"  10   VISNOTIFY 0 3                                  [Ln 3, Col 0 - Ln 3, Col 7]\n" +
-        $"  11   HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 7]\n" +
+        $"  12   VISNOTIFY 0 5                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
+        $"  13   SETELEM   0 -1 -1          ; 1 1               [Ln 3, Col 0 - Ln 3, Col 7]\n" +
+        $"  14   VISNOTIFY 0 6                                  [Ln 3, Col 0 - Ln 3, Col 7]\n" +
+        $"  15   HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 7]\n" +
         $"Notifications\n" +
         $"  0    Notification.VariableDefined: 'a' Global 7\n" +
-        $"  1    Notification.Assignment: 'a' Global 0\n" +
-        $"  2    Notification.GlobalLoaded: 0 'a'\n" +
-        $"  3    Notification.SubscriptAssignment: 0 250 250\n"
+        $"  1    Notification.TempRegisterAllocated: 0\n" +
+        $"  2    Notification.TempRegisterAllocated: 1\n" +
+        $"  3    Notification.TempRegisterAllocated: 2\n" +
+        $"  4    Notification.Assignment: 'a' Global 0\n" +
+        $"  5    Notification.GlobalLoaded: 0 'a'\n" +
+        $"  6    Notification.SubscriptAssignment: 0 250 250\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] { typeof(Event.Assignment) }, RunMode.Interactive);
     }
@@ -448,26 +472,32 @@ def func():
       string expected = (
         $"Function <main>\n" +
         $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 4, Col 9]\n" +
-        $"  2    LOADK     0 -1             ; Func <func>       [Ln 2, Col 0 - Ln 4, Col 9]\n" +
-        $"  3    SETGLOB   0 {_firstGlob}" +
+        $"  2    VISNOTIFY 0 1                                  [Ln 2, Col 0 - Ln 4, Col 9]\n" +
+        $"  3    LOADK     0 -1             ; Func <func>       [Ln 2, Col 0 - Ln 4, Col 9]\n" +
+        $"  4    SETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 2, Col 0 - Ln 4, Col 9]\n" +
-        $"  4    HALT      1 0                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
+        $"  5    HALT      1 0                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
         $"Notifications\n" +
         $"  0    Notification.VariableDefined: 'func' Global 7\n" +
+        $"  1    Notification.TempRegisterAllocated: 0\n" +
         $"\n" +
         $"Function <func>\n" +
         $"  1    VISNOTIFY 0 0                                  [Ln 3, Col 2 - Ln 3, Col 2]\n" +
-        $"  2    LOADK     1 -1             ; 1                 [Ln 3, Col 7 - Ln 3, Col 7]\n" +
-        $"  3    LOADK     2 -2             ; 2                 [Ln 3, Col 10 - Ln 3, Col 10]\n" +
-        $"  4    NEWLIST   0 1 2                                [Ln 3, Col 6 - Ln 3, Col 11]\n" +
-        $"  5    VISNOTIFY 0 1                                  [Ln 3, Col 2 - Ln 3, Col 11]\n" +
-        $"  6    SETELEM   0 -1 -1          ; 1 1               [Ln 4, Col 2 - Ln 4, Col 9]\n" +
-        $"  7    VISNOTIFY 0 2                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
-        $"  8    RETURN    0 0                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
+        $"  2    VISNOTIFY 0 1                                  [Ln 3, Col 6 - Ln 3, Col 11]\n" +
+        $"  3    LOADK     1 -1             ; 1                 [Ln 3, Col 7 - Ln 3, Col 7]\n" +
+        $"  4    VISNOTIFY 0 2                                  [Ln 3, Col 6 - Ln 3, Col 11]\n" +
+        $"  5    LOADK     2 -2             ; 2                 [Ln 3, Col 10 - Ln 3, Col 10]\n" +
+        $"  6    NEWLIST   0 1 2                                [Ln 3, Col 6 - Ln 3, Col 11]\n" +
+        $"  7    VISNOTIFY 0 3                                  [Ln 3, Col 2 - Ln 3, Col 11]\n" +
+        $"  8    SETELEM   0 -1 -1          ; 1 1               [Ln 4, Col 2 - Ln 4, Col 9]\n" +
+        $"  9    VISNOTIFY 0 4                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
+        $"  10   RETURN    0 0                                  [Ln 4, Col 2 - Ln 4, Col 9]\n" +
         $"Notifications\n" +
         $"  0    Notification.VariableDefined: 'func.a' Local 0\n" +
-        $"  1    Notification.Assignment: 'func.a' Local 0\n" +
-        $"  2    Notification.SubscriptAssignment: 0 250 250\n"
+        $"  1    Notification.TempRegisterAllocated: 1\n" +
+        $"  2    Notification.TempRegisterAllocated: 2\n" +
+        $"  3    Notification.Assignment: 'func.a' Local 0\n" +
+        $"  4    Notification.SubscriptAssignment: 0 250 250\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] { typeof(Event.Assignment) }, RunMode.Interactive);
     }
@@ -481,28 +511,39 @@ a[0][1] = 1
       string expected = (
         $"Function <main>\n" +
         $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 2, Col 0]\n" +
-        $"  2    LOADK     2 -1             ; 1                 [Ln 2, Col 6 - Ln 2, Col 6]\n" +
-        $"  3    LOADK     3 -2             ; 2                 [Ln 2, Col 9 - Ln 2, Col 9]\n" +
-        $"  4    NEWLIST   1 2 2                                [Ln 2, Col 5 - Ln 2, Col 10]\n" +
-        $"  5    LOADK     2 -3             ; 3                 [Ln 2, Col 13 - Ln 2, Col 13]\n" +
-        $"  6    NEWLIST   0 1 2                                [Ln 2, Col 4 - Ln 2, Col 14]\n" +
-        $"  7    SETGLOB   0 {_firstGlob}" +
+        $"  2    VISNOTIFY 0 1                                  [Ln 2, Col 4 - Ln 2, Col 14]\n" +
+        $"  3    VISNOTIFY 0 2                                  [Ln 2, Col 4 - Ln 2, Col 14]\n" +
+        $"  4    VISNOTIFY 0 3                                  [Ln 2, Col 5 - Ln 2, Col 10]\n" +
+        $"  5    LOADK     2 -1             ; 1                 [Ln 2, Col 6 - Ln 2, Col 6]\n" +
+        $"  6    VISNOTIFY 0 4                                  [Ln 2, Col 5 - Ln 2, Col 10]\n" +
+        $"  7    LOADK     3 -2             ; 2                 [Ln 2, Col 9 - Ln 2, Col 9]\n" +
+        $"  8    NEWLIST   1 2 2                                [Ln 2, Col 5 - Ln 2, Col 10]\n" +
+        $"  9    VISNOTIFY 0 3                                  [Ln 2, Col 4 - Ln 2, Col 14]\n" +
+        $"  10   LOADK     2 -3             ; 3                 [Ln 2, Col 13 - Ln 2, Col 13]\n" +
+        $"  11   NEWLIST   0 1 2                                [Ln 2, Col 4 - Ln 2, Col 14]\n" +
+        $"  12   SETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 2, Col 0 - Ln 2, Col 14]\n" +
-        $"  8    VISNOTIFY 0 1                                  [Ln 2, Col 0 - Ln 2, Col 14]\n" +
-        $"  9    GETGLOB   1 {_firstGlob}" +
+        $"  13   VISNOTIFY 0 5                                  [Ln 2, Col 0 - Ln 2, Col 14]\n" +
+        $"  14   VISNOTIFY 0 1                                  [Ln 3, Col 0 - Ln 3, Col 3]\n" +
+        $"  15   VISNOTIFY 0 2                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
+        $"  16   GETGLOB   1 {_firstGlob}" +
         $"                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
-        $"  10   VISNOTIFY 0 2                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
-        $"  11   GETELEM   0 1 -4           ; 0                 [Ln 3, Col 0 - Ln 3, Col 3]\n" +
-        $"  12   VISNOTIFY 0 3                                  [Ln 3, Col 0 - Ln 3, Col 3]\n" +
-        $"  13   SETELEM   0 -1 -1          ; 1 1               [Ln 3, Col 0 - Ln 3, Col 10]\n" +
-        $"  14   VISNOTIFY 0 4                                  [Ln 3, Col 0 - Ln 3, Col 10]\n" +
-        $"  15   HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 10]\n" +
+        $"  17   VISNOTIFY 0 6                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
+        $"  18   GETELEM   0 1 -4           ; 0                 [Ln 3, Col 0 - Ln 3, Col 3]\n" +
+        $"  19   VISNOTIFY 0 7                                  [Ln 3, Col 0 - Ln 3, Col 3]\n" +
+        $"  20   SETELEM   0 -1 -1          ; 1 1               [Ln 3, Col 0 - Ln 3, Col 10]\n" +
+        $"  21   VISNOTIFY 0 8                                  [Ln 3, Col 0 - Ln 3, Col 10]\n" +
+        $"  22   HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 10]\n" +
         $"Notifications\n" +
         $"  0    Notification.VariableDefined: 'a' Global 7\n" +
-        $"  1    Notification.Assignment: 'a' Global 0\n" +
-        $"  2    Notification.GlobalLoaded: 1 'a'\n" +
-        $"  3    Notification.ElementLoaded: 0 1 253\n" +
-        $"  4    Notification.SubscriptAssignment: 0 250 250\n"
+        $"  1    Notification.TempRegisterAllocated: 0\n" +
+        $"  2    Notification.TempRegisterAllocated: 1\n" +
+        $"  3    Notification.TempRegisterAllocated: 2\n" +
+        $"  4    Notification.TempRegisterAllocated: 3\n" +
+        $"  5    Notification.Assignment: 'a' Global 0\n" +
+        $"  6    Notification.GlobalLoaded: 1 'a'\n" +
+        $"  7    Notification.ElementLoaded: 0 1 253\n" +
+        $"  8    Notification.SubscriptAssignment: 0 250 250\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] { typeof(Event.Assignment) }, RunMode.Interactive);
     }
@@ -520,25 +561,32 @@ x = add(1, 2)
         $"Function <main>\n" +
         $"  1    VISNOTIFY 0 1                                  [Ln 2, Col 0 - Ln 2, Col 0]\n" +
         $"  2    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 4, Col 9]\n" +
-        $"  3    LOADK     0 -1             ; Func <add>        [Ln 2, Col 0 - Ln 4, Col 9]\n" +
-        $"  4    SETGLOB   0 {_firstGlob}" +
+        $"  3    VISNOTIFY 0 2                                  [Ln 2, Col 0 - Ln 4, Col 9]\n" +
+        $"  4    LOADK     0 -1             ; Func <add>        [Ln 2, Col 0 - Ln 4, Col 9]\n" +
+        $"  5    SETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 2, Col 0 - Ln 4, Col 9]\n" +
-        $"  5    VISNOTIFY 0 1                                  [Ln 6, Col 0 - Ln 6, Col 0]\n" +
-        $"  6    VISNOTIFY 0 2                                  [Ln 6, Col 0 - Ln 6, Col 0]\n" +
-        $"  7    GETGLOB   0 {_firstGlob}" +
+        $"  6    VISNOTIFY 0 1                                  [Ln 6, Col 0 - Ln 6, Col 0]\n" +
+        $"  7    VISNOTIFY 0 3                                  [Ln 6, Col 0 - Ln 6, Col 0]\n" +
+        $"  8    VISNOTIFY 0 2                                  [Ln 6, Col 4 - Ln 6, Col 12]\n" +
+        $"  9    GETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 6, Col 4 - Ln 6, Col 6]\n" +
-        $"  8    LOADK     1 -2             ; 1                 [Ln 6, Col 8 - Ln 6, Col 8]\n" +
-        $"  9    LOADK     2 -3             ; 2                 [Ln 6, Col 11 - Ln 6, Col 11]\n" +
-        $"  10   CALL      0 2 0                                [Ln 6, Col 4 - Ln 6, Col 12]\n" +
-        $"  11   VISNOTIFY 0 3                                  [Ln 6, Col 4 - Ln 6, Col 12]\n" +
-        $"  12   SETGLOB   0 {_firstGlob + 1}" +
+        $"  10   VISNOTIFY 0 4                                  [Ln 6, Col 8 - Ln 6, Col 8]\n" +
+        $"  11   LOADK     1 -2             ; 1                 [Ln 6, Col 8 - Ln 6, Col 8]\n" +
+        $"  12   VISNOTIFY 0 5                                  [Ln 6, Col 11 - Ln 6, Col 11]\n" +
+        $"  13   LOADK     2 -3             ; 2                 [Ln 6, Col 11 - Ln 6, Col 11]\n" +
+        $"  14   CALL      0 2 0                                [Ln 6, Col 4 - Ln 6, Col 12]\n" +
+        $"  15   VISNOTIFY 0 6                                  [Ln 6, Col 4 - Ln 6, Col 12]\n" +
+        $"  16   SETGLOB   0 {_firstGlob + 1}" +
         $"                                  [Ln 6, Col 0 - Ln 6, Col 12]\n" +
-        $"  13   HALT      1 0                                  [Ln 6, Col 0 - Ln 6, Col 12]\n" +
+        $"  17   HALT      1 0                                  [Ln 6, Col 0 - Ln 6, Col 12]\n" +
         $"Notifications\n" +
         $"  0    Notification.VariableDefined: 'add' Global {_firstGlob}\n" +
         $"  1    Notification.SingleStep\n" +
-        $"  2    Notification.VariableDefined: 'x' Global {_firstGlob + 1}\n" +
-        $"  3    Notification.VariableDeleted: 0\n" +
+        $"  2    Notification.TempRegisterAllocated: 0\n" +
+        $"  3    Notification.VariableDefined: 'x' Global {_firstGlob + 1}\n" +
+        $"  4    Notification.TempRegisterAllocated: 1\n" +
+        $"  5    Notification.TempRegisterAllocated: 2\n" +
+        $"  6    Notification.VariableDeleted: 0\n" +
         $"\n" +
         $"Function <add>\n" +
         $"  1    VISNOTIFY 0 1                                  [Ln 2, Col 0 - Ln 2, Col 0]\n" +
@@ -572,16 +620,20 @@ x = add(1, 2)
       string expected = (
         $"Function <main>\n" +
         $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 3, Col 4]\n" +
-        $"  2    GETGLOB   0 {_printValFunc}" +
+        $"  2    VISNOTIFY 0 1                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
+        $"  3    GETGLOB   0 {_printValFunc}" +
         $"                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
-        $"  3    ADD       1 -1 -2          ; 1 2               [Ln 3, Col 0 - Ln 3, Col 4]\n" +
-        $"  4    VISNOTIFY 0 1                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
-        $"  5    CALL      0 1 0                                [Ln 3, Col 0 - Ln 3, Col 4]\n" +
-        $"  6    VISNOTIFY 1 0                                  [Ln 2, Col 0 - Ln 3, Col 4]\n" +
-        $"  7    HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
+        $"  4    VISNOTIFY 0 2                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
+        $"  5    ADD       1 -1 -2          ; 1 2               [Ln 3, Col 0 - Ln 3, Col 4]\n" +
+        $"  6    VISNOTIFY 0 3                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
+        $"  7    CALL      0 1 0                                [Ln 3, Col 0 - Ln 3, Col 4]\n" +
+        $"  8    VISNOTIFY 1 0                                  [Ln 2, Col 0 - Ln 3, Col 4]\n" +
+        $"  9    HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
         $"Notifications\n" +
         $"  0    Notification.VTag: Add\n" +
-        $"  1    Notification.Binary: 250 Add 251 1\n"
+        $"  1    Notification.TempRegisterAllocated: 0\n" +
+        $"  2    Notification.TempRegisterAllocated: 1\n" +
+        $"  3    Notification.Binary: 250 Add 251 1\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] {
         typeof(Event.Binary),
@@ -599,16 +651,20 @@ x = add(1, 2)
       string expected = (
         $"Function <main>\n" +
         $"  1    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 3, Col 4]\n" +
-        $"  2    GETGLOB   0 {_printValFunc}" +
+        $"  2    VISNOTIFY 0 1                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
+        $"  3    GETGLOB   0 {_printValFunc}" +
         $"                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
-        $"  3    ADD       1 -1 -2          ; 1 2               [Ln 3, Col 0 - Ln 3, Col 4]\n" +
-        $"  4    VISNOTIFY 0 1                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
-        $"  5    CALL      0 1 0                                [Ln 3, Col 0 - Ln 3, Col 4]\n" +
-        $"  6    VISNOTIFY 1 0                                  [Ln 2, Col 0 - Ln 3, Col 4]\n" +
-        $"  7    HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
+        $"  4    VISNOTIFY 0 2                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
+        $"  5    ADD       1 -1 -2          ; 1 2               [Ln 3, Col 0 - Ln 3, Col 4]\n" +
+        $"  6    VISNOTIFY 0 3                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
+        $"  7    CALL      0 1 0                                [Ln 3, Col 0 - Ln 3, Col 4]\n" +
+        $"  8    VISNOTIFY 1 0                                  [Ln 2, Col 0 - Ln 3, Col 4]\n" +
+        $"  9    HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 4]\n" +
         $"Notifications\n" +
         $"  0    Notification.VTag: Add(1: 250, 2: 251)\n" +
-        $"  1    Notification.Binary: 250 Add 251 1\n"
+        $"  1    Notification.TempRegisterAllocated: 0\n" +
+        $"  2    Notification.TempRegisterAllocated: 1\n" +
+        $"  3    Notification.Binary: 250 Add 251 1\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] {
         typeof(Event.Binary),
@@ -630,35 +686,34 @@ x, y = 1, 1 + 2
         $"  2    VISNOTIFY 0 0                                  [Ln 2, Col 0 - Ln 4, Col 3]\n" +
         $"  3    VISNOTIFY 0 1                                  [Ln 3, Col 0 - Ln 3, Col 0]\n" +
         $"  4    VISNOTIFY 0 2                                  [Ln 3, Col 3 - Ln 3, Col 3]\n" +
-        $"  5    LOADK     1 -1             ; 1                 [Ln 3, Col 7 - Ln 3, Col 7]\n" +
-        $"  6    ADD       2 -1 -2          ; 1 2               [Ln 3, Col 10 - Ln 3, Col 14]\n" +
-        $"  7    VISNOTIFY 0 3                                  [Ln 3, Col 10 - Ln 3, Col 14]\n" +
-        $"  8    NEWTUPLE  0 1 2                                [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  9    LOADK     2 -3             ; 0                 [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  10   GETELEM   1 0 2                                [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  11   SETGLOB   1 {_firstGlob}" +
+        $"  5    VISNOTIFY 0 3                                  [Ln 3, Col 7 - Ln 3, Col 7]\n" +
+        $"  6    LOADK     0 -1             ; 1                 [Ln 3, Col 7 - Ln 3, Col 7]\n" +
+        $"  7    VISNOTIFY 0 4                                  [Ln 3, Col 10 - Ln 3, Col 14]\n" +
+        $"  8    ADD       1 -1 -2          ; 1 2               [Ln 3, Col 10 - Ln 3, Col 14]\n" +
+        $"  9    VISNOTIFY 0 5                                  [Ln 3, Col 10 - Ln 3, Col 14]\n" +
+        $"  10   SETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  12   VISNOTIFY 0 4                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  13   LOADK     2 -1             ; 1                 [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  14   GETELEM   1 0 2                                [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  15   SETGLOB   1 {_firstGlob + 1}" +
+        $"  11   VISNOTIFY 0 6                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  12   SETGLOB   1 {_firstGlob + 1}" +
         $"                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  16   VISNOTIFY 0 5                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
-        $"  17   GETGLOB   0 {_firstGlob}" +
+        $"  13   VISNOTIFY 0 7                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  14   GETGLOB   0 {_firstGlob}" +
         $"                                  [Ln 2, Col 12 - Ln 2, Col 12]\n" +
-        $"  18   GETGLOB   1 {_firstGlob + 1}" +
+        $"  15   GETGLOB   1 {_firstGlob + 1}" +
         $"                                  [Ln 2, Col 18 - Ln 2, Col 18]\n" +
-        $"  19   ADD       2 -1 -2          ; 1 2               [Ln 2, Col 21 - Ln 2, Col 25]\n" +
-        $"  20   VISNOTIFY 1 6                                  [Ln 2, Col 0 - Ln 4, Col 3]\n" +
-        $"  21   HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
+        $"  16   ADD       2 -1 -2          ; 1 2               [Ln 2, Col 21 - Ln 2, Col 25]\n" +
+        $"  17   VISNOTIFY 1 8                                  [Ln 2, Col 0 - Ln 4, Col 3]\n" +
+        $"  18   HALT      1 0                                  [Ln 3, Col 0 - Ln 3, Col 14]\n" +
         $"Notifications\n" +
         $"  0    Notification.VTag: Assign(x: null, 1: 250, y: null, 1+2: 2)\n" +
         $"  1    Notification.VariableDefined: 'x' Global {_firstGlob}\n" +
         $"  2    Notification.VariableDefined: 'y' Global {_firstGlob + 1}\n" +
-        $"  3    Notification.Binary: 250 Add 251 2\n" +
-        $"  4    Notification.Assignment: 'x' Global 1\n" +
-        $"  5    Notification.Assignment: 'y' Global 1\n" +
-        $"  6    Notification.VTag: Assign(x: 0, 1: 250, y: 1, 1+2: 2)\n"
+        $"  3    Notification.TempRegisterAllocated: 0\n" +
+        $"  4    Notification.TempRegisterAllocated: 1\n" +
+        $"  5    Notification.Binary: 250 Add 251 1\n" +
+        $"  6    Notification.Assignment: 'x' Global 0\n" +
+        $"  7    Notification.Assignment: 'y' Global 1\n" +
+        $"  8    Notification.VTag: Assign(x: 0, 1: 250, y: 1, 1+2: 2)\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(source, expected, new Type[] {
         typeof(Event.Assignment),

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
@@ -52,16 +52,11 @@ namespace SeedLang.Interpreter.Tests {
       );
       string expected = (
           $"Function <main>\n" +
-          $"  1    LOADK     1 -1             ; 1                 {_range}\n" +
-          $"  2    LOADK     2 -2             ; 2                 {_range}\n" +
-          $"  3    NEWTUPLE  0 1 2                                {_range}\n" +
-          $"  4    LOADK     2 -3             ; 0                 {_range}\n" +
-          $"  5    GETELEM   1 0 2                                {_range}\n" +
-          $"  6    SETGLOB   1 {_firstGlob}                                  {_range}\n" +
-          $"  7    LOADK     2 -1             ; 1                 {_range}\n" +
-          $"  8    GETELEM   1 0 2                                {_range}\n" +
-          $"  9    SETGLOB   1 {_firstGlob + 1}                                  {_range}\n" +
-          $"  10   HALT      1 0                                  {_range}\n"
+          $"  1    LOADK     0 -1             ; 1                 {_range}\n" +
+          $"  2    LOADK     1 -2             ; 2                 {_range}\n" +
+          $"  3    SETGLOB   0 {_firstGlob}                                  {_range}\n" +
+          $"  4    SETGLOB   1 {_firstGlob + 1}                                  {_range}\n" +
+          $"  5    HALT      1 0                                  {_range}\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(program, expected, RunMode.Interactive);
     }
@@ -190,17 +185,15 @@ namespace SeedLang.Interpreter.Tests {
       );
       string expected = (
           $"Function <main>\n" +
-          $"  1    LOADK     1 -1             ; 1                 {_range}\n" +
-          $"  2    LOADK     2 -2             ; 2                 {_range}\n" +
-          $"  3    NEWTUPLE  0 1 2                                {_range}\n" +
-          $"  4    LOADK     2 -3             ; 0                 {_range}\n" +
-          $"  5    GETELEM   1 0 2                                {_range}\n" +
-          $"  6    SETGLOB   1 {_firstGlob}                                  {_range}\n" +
-          $"  7    LOADK     2 -1             ; 1                 {_range}\n" +
-          $"  8    GETELEM   1 0 2                                {_range}\n" +
-          $"  9    SETGLOB   1 {_firstGlob + 1}                                  {_range}\n" +
-          $"  10   SETGLOB   0 {_firstGlob + 2}                                  {_range}\n" +
-          $"  11   HALT      1 0                                  {_range}\n"
+          $"  1    LOADK     0 -1             ; 1                 {_range}\n" +
+          $"  2    LOADK     1 -2             ; 2                 {_range}\n" +
+          $"  3    SETGLOB   0 {_firstGlob}                                  {_range}\n" +
+          $"  4    SETGLOB   1 {_firstGlob + 1}                                  {_range}\n" +
+          $"  5    LOADK     3 -1             ; 1                 {_range}\n" +
+          $"  6    LOADK     4 -2             ; 2                 {_range}\n" +
+          $"  7    NEWTUPLE  2 3 2                                {_range}\n" +
+          $"  8    SETGLOB   2 {_firstGlob + 2}                                  {_range}\n" +
+          $"  9    HALT      1 0                                  {_range}\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(program, expected, RunMode.Interactive);
     }
@@ -646,20 +639,15 @@ namespace SeedLang.Interpreter.Tests {
           $"  3    LOADK     3 -3             ; 3                 {_range}\n" +
           $"  4    NEWLIST   0 1 3                                {_range}\n" +
           $"  5    SETGLOB   0 {_firstGlob}                                  {_range}\n" +
-          $"  6    GETGLOB   2 {_firstGlob}                                  {_range}\n" +
-          $"  7    GETELEM   1 2 -1           ; 1                 {_range}\n" +
-          $"  8    GETGLOB   3 {_firstGlob}                                  {_range}\n" +
-          $"  9    GETELEM   2 3 -4           ; 0                 {_range}\n" +
-          $"  10   NEWTUPLE  0 1 2                                {_range}\n" +
-          $"  11   LOADK     2 -4             ; 0                 {_range}\n" +
-          $"  12   GETELEM   1 0 2                                {_range}\n" +
-          $"  13   GETGLOB   3 {_firstGlob}                                  {_range}\n" +
-          $"  14   SETELEM   3 -4 1           ; 0                 {_range}\n" +
-          $"  15   LOADK     2 -1             ; 1                 {_range}\n" +
-          $"  16   GETELEM   1 0 2                                {_range}\n" +
-          $"  17   GETGLOB   3 {_firstGlob}                                  {_range}\n" +
-          $"  18   SETELEM   3 -1 1           ; 1                 {_range}\n" +
-          $"  19   HALT      1 0                                  {_range}\n"
+          $"  6    GETGLOB   1 {_firstGlob}                                  {_range}\n" +
+          $"  7    GETELEM   0 1 -1           ; 1                 {_range}\n" +
+          $"  8    GETGLOB   2 {_firstGlob}                                  {_range}\n" +
+          $"  9    GETELEM   1 2 -4           ; 0                 {_range}\n" +
+          $"  10   GETGLOB   2 {_firstGlob}                                  {_range}\n" +
+          $"  11   SETELEM   2 -4 0           ; 0                 {_range}\n" +
+          $"  12   GETGLOB   3 {_firstGlob}                                  {_range}\n" +
+          $"  13   SETELEM   3 -1 1           ; 1                 {_range}\n" +
+          $"  14   HALT      1 0                                  {_range}\n"
       ).Replace("\n", Environment.NewLine);
       TestCompiler(program, expected, RunMode.Interactive);
     }

--- a/csharp/tests/SeedLang.Tests/Interpreter/NotificationsTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/NotificationsTests.cs
@@ -25,7 +25,7 @@ namespace SeedLang.Interpreter.Tests {
       var assignment = new Notification.Assignment("a", VariableType.Global, 1);
       (assignment == new Notification.Assignment("a", VariableType.Global, 1)).Should().Be(true);
       (assignment != null).Should().Be(true);
-      assignment.ToString().Should().Be($"Notification.Assignment: 'a': Global 1");
+      assignment.ToString().Should().Be($"Notification.Assignment: 'a' Global 1");
 
       var binary = new Notification.Binary(1, BinaryOperator.Add, 2, 3);
       (binary == new Notification.Binary(1, BinaryOperator.Add, 2, 3)).Should().Be(true);

--- a/csharp/tests/SeedLang.Tests/Interpreter/NotificationsTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/NotificationsTests.cs
@@ -57,11 +57,6 @@ namespace SeedLang.Interpreter.Tests {
       (subscriptAssign != null).Should().Be(true);
       subscriptAssign.ToString().Should().Be("Notification.SubscriptAssignment: 0 1 2");
 
-      var unary = new Notification.Unary(UnaryOperator.Positive, 1, 2);
-      (unary == new Notification.Unary(UnaryOperator.Positive, 1, 2)).Should().Be(true);
-      (unary != null).Should().Be(true);
-      unary.ToString().Should().Be("Notification.Unary: Positive 1 2");
-
       var info = new VariableInfo("a", VariableType.Global, 1);
       var variableDefined = new Notification.VariableDefined(info);
       (variableDefined == new Notification.VariableDefined(info)).Should().Be(true);
@@ -89,7 +84,6 @@ namespace SeedLang.Interpreter.Tests {
         [globalLoaded] = "globalLoaded",
         [singleStep] = "singleStep",
         [subscriptAssign] = "subscriptAssign",
-        [unary] = "unary",
         [variableDefined] = "variableDefined",
         [variableDeleted] = "variableDeleted",
         [vTag] = "vTag",
@@ -115,9 +109,6 @@ namespace SeedLang.Interpreter.Tests {
 
       dict[subscriptAssign].Should().Be("subscriptAssign");
       dict[new Notification.SubscriptAssignment(0, 1, 2)].Should().Be("subscriptAssign");
-
-      dict[unary].Should().Be("unary");
-      dict[new Notification.Unary(UnaryOperator.Positive, 1, 2)].Should().Be("unary");
 
       dict[variableDefined].Should().Be("variableDefined");
       info = new VariableInfo("a", VariableType.Global, 1);

--- a/csharp/tests/SeedLang.Tests/Interpreter/VMNotificationTest.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/VMNotificationTest.cs
@@ -28,55 +28,17 @@ namespace SeedLang.Interpreter.Tests {
     [Fact]
     public void TestAssignment() {
       string source = @"
-a = 1
-b = a
+a = [1, 2]
+for i in range(2):
+  a[i] = 5
 ";
       (string _, IEnumerable<string> events) = Run(source, new Type[] { typeof(Event.Assignment) });
       var expected = new string[] {
-        "[Ln 2, Col 0 - Ln 2, Col 4] a:Global = 1",
-        "[Ln 3, Col 0 - Ln 3, Col 4] b:Global = a:Global 1",
-      };
-      events.Should().BeEquivalentTo(expected);
-    }
-
-    [Fact]
-    public void TestAssignment1() {
-      string source = @"
-a, b = 1, 2
-";
-      (string _, IEnumerable<string> events) = Run(source, new Type[] { typeof(Event.Assignment) });
-      var expected = new string[] {
-        "[Ln 2, Col 0 - Ln 2, Col 10] a:Global = 1",
-        "[Ln 2, Col 0 - Ln 2, Col 10] b:Global = 2",
-      };
-      events.Should().BeEquivalentTo(expected);
-    }
-
-    [Fact]
-    public void TestAssignment2() {
-      string source = @"
-a = 1
-a += 1
-";
-      (string _, IEnumerable<string> events) = Run(source, new Type[] { typeof(Event.Assignment) });
-      var expected = new string[] {
-        "[Ln 2, Col 0 - Ln 2, Col 4] a:Global = 1",
-        "[Ln 3, Col 0 - Ln 3, Col 5] a:Global = 2",
-      };
-      events.Should().BeEquivalentTo(expected);
-    }
-
-    [Fact]
-    public void TestAssignment3() {
-      string source = @"
-for i in range(3):
-  pass
-";
-      (string _, IEnumerable<string> events) = Run(source, new Type[] { typeof(Event.Assignment) });
-      var expected = new string[] {
-        "[Ln 2, Col 4 - Ln 2, Col 4] i:Global = 0",
-        "[Ln 2, Col 4 - Ln 2, Col 4] i:Global = 1",
-        "[Ln 2, Col 4 - Ln 2, Col 4] i:Global = 2",
+        "[Ln 2, Col 0 - Ln 2, Col 9] a:Global = [1, 2]",
+        "[Ln 3, Col 4 - Ln 3, Col 4] i:Global = 0",
+        "[Ln 4, Col 2 - Ln 4, Col 9] a:Global[0] = 5",
+        "[Ln 3, Col 4 - Ln 3, Col 4] i:Global = 1",
+        "[Ln 4, Col 2 - Ln 4, Col 9] a:Global[1] = 5",
       };
       events.Should().BeEquivalentTo(expected);
     }

--- a/csharp/tests/SeedLang.Tests/Interpreter/VMNotificationTest.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/VMNotificationTest.cs
@@ -26,6 +26,62 @@ using Xunit;
 namespace SeedLang.Interpreter.Tests {
   public class VMNotificationTests {
     [Fact]
+    public void TestAssignment() {
+      string source = @"
+a = 1
+b = a
+";
+      (string _, IEnumerable<string> events) = Run(source, new Type[] { typeof(Event.Assignment) });
+      var expected = new string[] {
+        "[Ln 2, Col 0 - Ln 2, Col 4] a:Global = 1",
+        "[Ln 3, Col 0 - Ln 3, Col 4] b:Global = a:Global 1",
+      };
+      events.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void TestAssignment1() {
+      string source = @"
+a, b = 1, 2
+";
+      (string _, IEnumerable<string> events) = Run(source, new Type[] { typeof(Event.Assignment) });
+      var expected = new string[] {
+        "[Ln 2, Col 0 - Ln 2, Col 10] a:Global = 1",
+        "[Ln 2, Col 0 - Ln 2, Col 10] b:Global = 2",
+      };
+      events.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void TestAssignment2() {
+      string source = @"
+a = 1
+a += 1
+";
+      (string _, IEnumerable<string> events) = Run(source, new Type[] { typeof(Event.Assignment) });
+      var expected = new string[] {
+        "[Ln 2, Col 0 - Ln 2, Col 4] a:Global = 1",
+        "[Ln 3, Col 0 - Ln 3, Col 5] a:Global = 2",
+      };
+      events.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void TestAssignment3() {
+      string source = @"
+for i in range(3):
+  pass
+";
+      (string _, IEnumerable<string> events) = Run(source, new Type[] { typeof(Event.Assignment) });
+      var expected = new string[] {
+        "[Ln 2, Col 4 - Ln 2, Col 4] i:Global = 0",
+        "[Ln 2, Col 4 - Ln 2, Col 4] i:Global = 1",
+        "[Ln 2, Col 4 - Ln 2, Col 4] i:Global = 2",
+      };
+      events.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
     public void TestComparison() {
       string source = @"
 str = 'string'

--- a/csharp/tests/SeedLang.Tests/Interpreter/VMNotificationTest.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/VMNotificationTest.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using FluentAssertions;
 using SeedLang.Ast;
 using SeedLang.Common;
@@ -61,14 +60,14 @@ x = add(1, 2)
             typeof(Event.VariableDeleted),
           });
       var expected = new string[] {
-        "[Ln 2, Col 0 - Ln 4, Col 9] VariableDefined: add: Global",
-        "[Ln 6, Col 0 - Ln 6, Col 0] VariableDefined: x: Global",
-        "[Ln 2, Col 8 - Ln 2, Col 8] VariableDefined: add.a: Local",
-        "[Ln 2, Col 11 - Ln 2, Col 11] VariableDefined: add.b: Local",
-        "[Ln 3, Col 2 - Ln 3, Col 2] VariableDefined: add.c: Local",
-        "[Ln 6, Col 4 - Ln 6, Col 12] VariableDeleted: add.c: Local",
-        "[Ln 6, Col 4 - Ln 6, Col 12] VariableDeleted: add.b: Local",
-        "[Ln 6, Col 4 - Ln 6, Col 12] VariableDeleted: add.a: Local",
+        "[Ln 2, Col 0 - Ln 4, Col 9] VariableDefined: add (Global)",
+        "[Ln 6, Col 0 - Ln 6, Col 0] VariableDefined: x (Global)",
+        "[Ln 2, Col 8 - Ln 2, Col 8] VariableDefined: add.a (Local)",
+        "[Ln 2, Col 11 - Ln 2, Col 11] VariableDefined: add.b (Local)",
+        "[Ln 3, Col 2 - Ln 3, Col 2] VariableDefined: add.c (Local)",
+        "[Ln 6, Col 4 - Ln 6, Col 12] VariableDeleted: add.c (Local)",
+        "[Ln 6, Col 4 - Ln 6, Col 12] VariableDeleted: add.b (Local)",
+        "[Ln 6, Col 4 - Ln 6, Col 12] VariableDeleted: add.a (Local)",
       };
       events.Should().BeEquivalentTo(expected);
     }
@@ -85,9 +84,9 @@ a[0][1] = 10
         typeof(Event.VariableDeleted),
       });
       var expected = new string[] {
-        "[Ln 2, Col 0 - Ln 2, Col 22] a: Global = [[1, 2, 3], [1, 2]]",
-        "[Ln 3, Col 0 - Ln 3, Col 11] (a: Global)[0][1] = 10",
-        "[Ln 2, Col 0 - Ln 2, Col 0] VariableDefined: a: Global",
+        "[Ln 2, Col 0 - Ln 2, Col 22] a:Global = [[1, 2, 3], [1, 2]]",
+        "[Ln 3, Col 0 - Ln 3, Col 11] a:Global[0][1] = 10",
+        "[Ln 2, Col 0 - Ln 2, Col 0] VariableDefined: a (Global)",
       };
       events.Should().BeEquivalentTo(expected);
     }

--- a/csharp/tests/SeedLang.Tests/Interpreter/VMNotificationTest.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/VMNotificationTest.cs
@@ -80,58 +80,16 @@ a = [[1, 2, 3], [1, 2]]
 a[0][1] = 10
 ";
       (string _, IEnumerable<string> events) = Run(source, new Type[] {
-        typeof(Event.SubscriptAssignment),
+        typeof(Event.Assignment),
         typeof(Event.VariableDefined),
         typeof(Event.VariableDeleted),
       });
       var expected = new string[] {
+        "[Ln 2, Col 0 - Ln 2, Col 22] a: Global = [[1, 2, 3], [1, 2]]",
         "[Ln 3, Col 0 - Ln 3, Col 11] (a: Global)[0][1] = 10",
         "[Ln 2, Col 0 - Ln 2, Col 0] VariableDefined: a: Global",
       };
       events.Should().BeEquivalentTo(expected);
-    }
-
-    [Fact]
-    public void TestQuickSort() {
-      string source = @"
-# [[ Data ]]
-a = [8, 1, 0, 5, 6, 3, 2, 4, 7, 1]
-
-# [[ Index(start, end) ]]
-def partition(start, end, a):
-  # [[ Index ]]
-  pivot_index = start
-  # [[ Save ]]
-  pivot = a[pivot_index]
-  while start < end:
-    while start < len(a) and a[start] <= pivot:
-      start += 1
-    while a[end] > pivot:
-      end -= 1
-    if (start < end):
-      # [[ Swap(start, end) ]]
-      a[start], a[end] = a[end], a[start]
-    # [[ Swap(end, pivot_index) ]]
-    a[end], a[pivot_index] = a[pivot_index], a[end]
-  return end
-
-
-# [[ Bounds(start, end) ]]
-def quick_sort(start, end, a):
-  if start < end:
-    mid = partition(start, end, a)
-    quick_sort(start, mid - 1, a)
-    quick_sort(mid + 1, end, a)
-
-
-quick_sort(0, len(a) - 1, a)
-print(a)
-";
-      (string output, IEnumerable<string> _) = Run(source, new Type[] {
-        typeof(Event.VTagEntered),
-        typeof(Event.VTagExited),
-      });
-      output.Should().Be("[0, 1, 1, 2, 3, 4, 5, 6, 7, 8]" + Environment.NewLine);
     }
 
     private static (string, IEnumerable<string>) Run(string source,
@@ -147,8 +105,7 @@ print(a)
       var compiler = new Compiler();
       Function func = compiler.Compile(program, vm.Env, vc, RunMode.Interactive);
       vm.Run(func);
-      var events = vh.EventsToString().Split(Environment.NewLine).Where(str => str != string.Empty);
-      return (stringWriter.ToString(), events);
+      return (stringWriter.ToString(), vh.EventStrings);
     }
   }
 }

--- a/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
@@ -33,9 +33,11 @@ namespace SeedLang.Interpreter.Tests {
                                                            AstHelper.NumberConstant(2)));
 
       (string output, VisualizerHelper vh) = Run(expr, new Type[] { typeof(Event.Binary) });
-      Assert.Equal("3" + Environment.NewLine, output);
-      var expectedOutput = $"{AstHelper.TextRange} 1 Add 2 = 3" + Environment.NewLine;
-      Assert.Equal(expectedOutput, vh.EventsToString());
+      output.Should().Be("3" + Environment.NewLine);
+      var expected = new string[] {
+        $"{AstHelper.TextRange} 1 Add 2 = 3",
+      };
+      vh.EventStrings.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
@@ -47,9 +49,8 @@ namespace SeedLang.Interpreter.Tests {
                                              AstHelper.NumberConstant(2)))
       );
 
-      (string output, VisualizerHelper vh) = Run(expr, Array.Empty<Type>());
-      Assert.Equal("True" + Environment.NewLine, output);
-      Assert.Equal("", vh.EventsToString());
+      (string output, VisualizerHelper _) = Run(expr, Array.Empty<Type>());
+      output.Should().Be("True" + Environment.NewLine);
     }
 
     [Fact]
@@ -58,9 +59,11 @@ namespace SeedLang.Interpreter.Tests {
                                                           AstHelper.NumberConstant(1)));
       var eventTypes = new Type[] { typeof(Event.Binary), typeof(Event.Unary) };
       (string output, VisualizerHelper vh) = Run(expr, eventTypes);
-      Assert.Equal("-1" + Environment.NewLine, output);
-      var expected = $"{AstHelper.TextRange} Negative 1 = -1" + Environment.NewLine;
-      Assert.Equal(expected, vh.EventsToString());
+      output.Should().Be("-1" + Environment.NewLine);
+      var expected = new string[] {
+        $"{AstHelper.TextRange} Negative 1 = -1",
+      };
+      vh.EventStrings.Should().BeEquivalentTo(expected);
 
       expr = AstHelper.ExpressionStmt(AstHelper.Unary(UnaryOperator.Negative,
         AstHelper.Binary(AstHelper.NumberConstant(1),
@@ -68,12 +71,12 @@ namespace SeedLang.Interpreter.Tests {
                          AstHelper.NumberConstant(2))
       ));
       (output, vh) = Run(expr, eventTypes);
-      Assert.Equal("-3" + Environment.NewLine, output);
-      expected = (
-        $"{AstHelper.TextRange} 1 Add 2 = 3\n" +
-        $"{AstHelper.TextRange} Negative 3 = -3\n"
-      ).Replace("\n", Environment.NewLine);
-      Assert.Equal(expected, vh.EventsToString());
+      output.Should().Be("-3" + Environment.NewLine);
+      expected = new string[] {
+        $"{AstHelper.TextRange} 1 Add 2 = 3",
+        $"{AstHelper.TextRange} Negative 3 = -3",
+      };
+      vh.EventStrings.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
@@ -97,13 +100,13 @@ namespace SeedLang.Interpreter.Tests {
         typeof(Event.FuncReturned),
       };
       (string output, VisualizerHelper vh) = Run(program, eventTypes);
-      Assert.Equal("3" + Environment.NewLine, output);
-      var expectedOutput = (
-        $"{AstHelper.TextRange} 1 Add 2 = 3\n" +
-        $"{AstHelper.TextRange} FuncCalled: add(1, 2)\n" +
-        $"{AstHelper.TextRange} FuncReturned: add 3\n"
-      ).Replace("\n", Environment.NewLine);
-      Assert.Equal(expectedOutput, vh.EventsToString());
+      output.Should().Be("3" + Environment.NewLine);
+      var expected = new string[] {
+        $"{AstHelper.TextRange} 1 Add 2 = 3",
+        $"{AstHelper.TextRange} FuncCalled: add(1, 2)",
+        $"{AstHelper.TextRange} FuncReturned: add 3",
+      };
+      vh.EventStrings.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
@@ -131,7 +134,7 @@ namespace SeedLang.Interpreter.Tests {
         AstHelper.ExpressionStmt(AstHelper.Call(AstHelper.Id(fib), AstHelper.NumberConstant(10)))
       );
       (string output, VisualizerHelper _) = Run(program, Array.Empty<Type>());
-      Assert.Equal("55" + Environment.NewLine, output);
+      output.Should().Be("55" + Environment.NewLine);
     }
 
     [Fact]
@@ -142,7 +145,7 @@ namespace SeedLang.Interpreter.Tests {
         AstHelper.NumberConstant(1)
       ));
       (string output, VisualizerHelper _) = Run(program, Array.Empty<Type>());
-      Assert.Equal("2" + Environment.NewLine, output);
+      output.Should().Be("2" + Environment.NewLine);
     }
 
     [Fact]
@@ -160,11 +163,13 @@ namespace SeedLang.Interpreter.Tests {
         ),
         AstHelper.ExpressionStmt(AstHelper.Subscript(AstHelper.Id(a), AstHelper.NumberConstant(1)))
       );
-      (string output, VisualizerHelper vh) = Run(program,
-                                                 new Type[] { typeof(Event.SubscriptAssignment) });
-      Assert.Equal("5" + Environment.NewLine, output);
-      var expected = $"{AstHelper.TextRange} (a: Global)[1] = 5" + Environment.NewLine;
-      Assert.Equal(expected, vh.EventsToString());
+      (string output, VisualizerHelper vh) = Run(program, new Type[] { typeof(Event.Assignment) });
+      output.Should().Be("5" + Environment.NewLine);
+      var expected = new string[] {
+        $"{AstHelper.TextRange} (a: Global)[1] = 5",
+        $"{AstHelper.TextRange} a: Global = [1, 2, 3]",
+      };
+      vh.EventStrings.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
@@ -176,7 +181,7 @@ namespace SeedLang.Interpreter.Tests {
         )
       );
       (string output, VisualizerHelper _) = Run(program, Array.Empty<Type>());
-      Assert.Equal("{1: 1, 'a': 2}" + Environment.NewLine, output);
+      output.Should().Be("{1: 1, 'a': 2}" + Environment.NewLine);
     }
 
     [Fact]
@@ -187,7 +192,7 @@ namespace SeedLang.Interpreter.Tests {
                         AstHelper.NumberConstant(3))
       );
       (string output, VisualizerHelper _) = Run(program, Array.Empty<Type>());
-      Assert.Equal("(1, 2, 3)" + Environment.NewLine, output);
+      output.Should().Be("(1, 2, 3)" + Environment.NewLine);
     }
 
     [Fact]
@@ -199,9 +204,11 @@ namespace SeedLang.Interpreter.Tests {
         AstHelper.ExpressionStmt(AstHelper.Id(name))
       );
       (string output, VisualizerHelper vh) = Run(program, new Type[] { typeof(Event.Assignment) });
-      Assert.Equal("1" + Environment.NewLine, output);
-      var expected = $"{AstHelper.TextRange} {name}: Global = 1" + Environment.NewLine;
-      Assert.Equal(expected, vh.EventsToString());
+      output.Should().Be("1" + Environment.NewLine);
+      var expected = new string[] {
+        $"{AstHelper.TextRange} {name}: Global = 1",
+      };
+      vh.EventStrings.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
@@ -222,12 +229,12 @@ namespace SeedLang.Interpreter.Tests {
         $"1\n" +
         $"2\n"
       ).Replace("\n", Environment.NewLine);
-      Assert.Equal(expectedOutput, output);
-      var expected = (
-        $"{AstHelper.TextRange} {a}: Global = 1\n" +
-        $"{AstHelper.TextRange} {b}: Global = 2\n"
-      ).Replace("\n", Environment.NewLine);
-      Assert.Equal(expected, vh.EventsToString());
+      output.Should().Be(expectedOutput);
+      var expected = new string[] {
+        $"{AstHelper.TextRange} {a}: Global = 1",
+        $"{AstHelper.TextRange} {b}: Global = 2",
+      };
+      vh.EventStrings.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
@@ -240,9 +247,11 @@ namespace SeedLang.Interpreter.Tests {
         AstHelper.ExpressionStmt(AstHelper.Id(name))
       );
       (string output, VisualizerHelper vh) = Run(block, new Type[] { typeof(Event.Assignment) });
-      Assert.Equal("(1, 2)" + Environment.NewLine, output);
-      var expected = $"{AstHelper.TextRange} {name}: Global = (1, 2)" + Environment.NewLine;
-      Assert.Equal(expected, vh.EventsToString());
+      output.Should().Be("(1, 2)" + Environment.NewLine);
+      var expected = new string[] {
+        $"{AstHelper.TextRange} {name}: Global = (1, 2)",
+      };
+      vh.EventStrings.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
@@ -262,7 +271,7 @@ namespace SeedLang.Interpreter.Tests {
         $"1\n" +
         $"2\n"
       ).Replace("\n", Environment.NewLine);
-      Assert.Equal(expectedOutput, output);
+      output.Should().Be(expectedOutput);
     }
 
     [Fact]
@@ -274,7 +283,7 @@ print(a, x, y, z)
 ";
       (string output, VisualizerHelper _) = Run(Parse(source), Array.Empty<Type>());
       var expectedOutput = $"[1, [...], 3] 1 2 (1, 2)" + Environment.NewLine;
-      Assert.Equal(expectedOutput, output);
+      output.Should().Be(expectedOutput);
     }
 
     [Fact]

--- a/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
@@ -102,7 +102,7 @@ namespace SeedLang.Interpreter.Tests {
       (string output, VisualizerHelper vh) = Run(program, eventTypes);
       output.Should().Be("3" + Environment.NewLine);
       var expected = new string[] {
-        $"{AstHelper.TextRange} 1 Add 2 = 3",
+        $"{AstHelper.TextRange} add.a:Local 1 Add add.b:Local 2 = 3",
         $"{AstHelper.TextRange} FuncCalled: add(1, 2)",
         $"{AstHelper.TextRange} FuncReturned: add 3",
       };
@@ -166,8 +166,8 @@ namespace SeedLang.Interpreter.Tests {
       (string output, VisualizerHelper vh) = Run(program, new Type[] { typeof(Event.Assignment) });
       output.Should().Be("5" + Environment.NewLine);
       var expected = new string[] {
-        $"{AstHelper.TextRange} (a: Global)[1] = 5",
-        $"{AstHelper.TextRange} a: Global = [1, 2, 3]",
+        $"{AstHelper.TextRange} a:Global[1] = 5",
+        $"{AstHelper.TextRange} a:Global = [1, 2, 3]",
       };
       vh.EventStrings.Should().BeEquivalentTo(expected);
     }
@@ -206,7 +206,7 @@ namespace SeedLang.Interpreter.Tests {
       (string output, VisualizerHelper vh) = Run(program, new Type[] { typeof(Event.Assignment) });
       output.Should().Be("1" + Environment.NewLine);
       var expected = new string[] {
-        $"{AstHelper.TextRange} {name}: Global = 1",
+        $"{AstHelper.TextRange} {name}:Global = 1",
       };
       vh.EventStrings.Should().BeEquivalentTo(expected);
     }
@@ -231,8 +231,8 @@ namespace SeedLang.Interpreter.Tests {
       ).Replace("\n", Environment.NewLine);
       output.Should().Be(expectedOutput);
       var expected = new string[] {
-        $"{AstHelper.TextRange} {a}: Global = 1",
-        $"{AstHelper.TextRange} {b}: Global = 2",
+        $"{AstHelper.TextRange} {a}:Global = 1",
+        $"{AstHelper.TextRange} {b}:Global = 2",
       };
       vh.EventStrings.Should().BeEquivalentTo(expected);
     }
@@ -249,7 +249,7 @@ namespace SeedLang.Interpreter.Tests {
       (string output, VisualizerHelper vh) = Run(block, new Type[] { typeof(Event.Assignment) });
       output.Should().Be("(1, 2)" + Environment.NewLine);
       var expected = new string[] {
-        $"{AstHelper.TextRange} {name}: Global = (1, 2)",
+        $"{AstHelper.TextRange} {name}:Global = (1, 2)",
       };
       vh.EventStrings.Should().BeEquivalentTo(expected);
     }

--- a/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
@@ -54,32 +54,6 @@ namespace SeedLang.Interpreter.Tests {
     }
 
     [Fact]
-    public void TestUnary() {
-      var expr = AstHelper.ExpressionStmt(AstHelper.Unary(UnaryOperator.Negative,
-                                                          AstHelper.NumberConstant(1)));
-      var eventTypes = new Type[] { typeof(Event.Binary), typeof(Event.Unary) };
-      (string output, VisualizerHelper vh) = Run(expr, eventTypes);
-      output.Should().Be("-1" + Environment.NewLine);
-      var expected = new string[] {
-        $"{AstHelper.TextRange} Negative 1 = -1",
-      };
-      vh.EventStrings.Should().BeEquivalentTo(expected);
-
-      expr = AstHelper.ExpressionStmt(AstHelper.Unary(UnaryOperator.Negative,
-        AstHelper.Binary(AstHelper.NumberConstant(1),
-                         BinaryOperator.Add,
-                         AstHelper.NumberConstant(2))
-      ));
-      (output, vh) = Run(expr, eventTypes);
-      output.Should().Be("-3" + Environment.NewLine);
-      expected = new string[] {
-        $"{AstHelper.TextRange} 1 Add 2 = 3",
-        $"{AstHelper.TextRange} Negative 3 = -3",
-      };
-      vh.EventStrings.Should().BeEquivalentTo(expected);
-    }
-
-    [Fact]
     public void TestFunctionCall() {
       string name = "add";
       string a = "a";

--- a/csharp/tests/SeedLang.Tests/Visualization/VisualizerCenterTests.cs
+++ b/csharp/tests/SeedLang.Tests/Visualization/VisualizerCenterTests.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
 using FluentAssertions;
 using SeedLang.Common;
 using SeedLang.Runtime;
@@ -112,7 +110,9 @@ namespace SeedLang.Visualization.Tests {
     }
 
     private static Event.Binary NewBinaryEvent() {
-      return new Event.Binary(new Value(1), BinaryOperator.Add, new Value(2), new Value(3),
+      var left = new Operand(null, new Value(1));
+      var right = new Operand(null, new Value(1));
+      return new Event.Binary(left, BinaryOperator.Add, right, new Value(3),
                               new TextRange(0, 1, 2, 3));
     }
   }

--- a/csharp/tests/SeedLang.Tests/Visualization/VisualizerCenterTests.cs
+++ b/csharp/tests/SeedLang.Tests/Visualization/VisualizerCenterTests.cs
@@ -110,8 +110,8 @@ namespace SeedLang.Visualization.Tests {
     }
 
     private static Event.Binary NewBinaryEvent() {
-      var left = new Operand(null, new Value(1));
-      var right = new Operand(null, new Value(1));
+      var left = new RValue(null, new Value(1));
+      var right = new RValue(null, new Value(1));
       return new Event.Binary(left, BinaryOperator.Add, right, new Value(3),
                               new TextRange(0, 1, 2, 3));
     }

--- a/examples/seedpython/scripts/sorting/bubble_sort.py
+++ b/examples/seedpython/scripts/sorting/bubble_sort.py
@@ -3,7 +3,6 @@ a = [8, 1, 0, 5, 6, 3, 2, 4, 7, 1]
 
 for i in range(len(a)):
     for j in range(len(a) - i - 1):
-        # [[ Compare(j, j+1) ]]
         if a[j] > a[j + 1]:
             # [[ Swap(j, j+1) ]]
             a[j], a[j + 1] = a[j + 1], a[j]

--- a/examples/seedpython/scripts/sorting/bubble_sort_2.py
+++ b/examples/seedpython/scripts/sorting/bubble_sort_2.py
@@ -3,7 +3,6 @@ a = [8, 1, 0, 5, 6, 3, 2, 4, 7, 1]
 
 for i in range(len(a)):
     for j in range(len(a) - i - 1):
-        # [[ Compare(j, j+1) ]]
         if a[j] > a[j + 1]:
             # [[ Swap(j, j+1)
             temp = a[j]

--- a/examples/seedpython/scripts/sorting/insertion_sort.py
+++ b/examples/seedpython/scripts/sorting/insertion_sort.py
@@ -5,7 +5,6 @@ for i in range(1, len(a)):
     # [[ Save(key, i) ]]
     key = a[i]
     j = i - 1
-    # [[ Compare(key, j) ]]
     while j >= 0 and key < a[j]:
         a[j + 1] = a[j]
         j -= 1


### PR DESCRIPTION
- Change `Binary` and `Comparison` events to include variable information.
- Remove `SubscriptAssignment` events, and combine it into `Assignment` events.
- Remove `Boolean` and `Unary` events. It seems that these events are not useful now.

After this change, the `Compare VTag` is not needed any more. Please run following command to see the notification of `Assignment`, `Binary` and `Comparison`.

```shell
dotnet run --project csharp/src/SeedLang.Shell -- -v "*" -f examples/seedpython/scripts/sorting/bubble_sort.py
```