### PR TITLE
Compile non-comparison and non-boolean expressions in the boolean expressions

### DIFF
--- a/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
@@ -455,6 +455,70 @@ namespace SeedLang.Interpreter.Tests {
     }
 
     [Fact]
+    public void TestCompileIfBooleanWithConstAndComparison() {
+      var program = AstHelper.If(
+        AstHelper.Boolean(
+          BooleanOperator.And,
+          AstHelper.BooleanConstant(false),
+          AstHelper.Comparison(AstHelper.NumberConstant(1),
+                               AstHelper.CompOps(ComparisonOperator.Less),
+                               AstHelper.NumberConstant(2))
+        ),
+        AstHelper.ExpressionStmt(AstHelper.NumberConstant(1)),
+        AstHelper.ExpressionStmt(AstHelper.NumberConstant(2))
+      );
+      string expected = (
+          $"Function <main>\n" +
+          $"  1    LOADBOOL  0 0 0                                {_range}\n" +
+          $"  2    TEST      0 0 1                                {_range}\n" +
+          $"  3    JMP       0 6              ; to 10             {_range}\n" +
+          $"  4    LT        1 -1 -2          ; 1 2               {_range}\n" +
+          $"  5    JMP       0 4              ; to 10             {_range}\n" +
+          $"  6    GETGLOB   0 {_printValFunc}                                  {_range}\n" +
+          $"  7    LOADK     1 -1             ; 1                 {_range}\n" +
+          $"  8    CALL      0 1 0                                {_range}\n" +
+          $"  9    JMP       0 3              ; to 13             {_range}\n" +
+          $"  10   GETGLOB   0 {_printValFunc}                                  {_range}\n" +
+          $"  11   LOADK     1 -2             ; 2                 {_range}\n" +
+          $"  12   CALL      0 1 0                                {_range}\n" +
+          $"  13   HALT      1 0                                  {_range}\n"
+      ).Replace("\n", Environment.NewLine);
+      TestCompiler(program, expected, RunMode.Interactive);
+    }
+
+    [Fact]
+    public void TestCompileIfBooleanWithComparisonOrConst() {
+      var program = AstHelper.If(
+        AstHelper.Boolean(
+          BooleanOperator.Or,
+          AstHelper.Comparison(AstHelper.NumberConstant(1),
+                               AstHelper.CompOps(ComparisonOperator.Less),
+                               AstHelper.NumberConstant(2)),
+          AstHelper.BooleanConstant(false)
+        ),
+        AstHelper.ExpressionStmt(AstHelper.NumberConstant(1)),
+        AstHelper.ExpressionStmt(AstHelper.NumberConstant(2))
+      );
+      string expected = (
+          $"Function <main>\n" +
+          $"  1    LT        0 -1 -2          ; 1 2               {_range}\n" +
+          $"  2    JMP       0 3              ; to 6              {_range}\n" +
+          $"  3    LOADBOOL  0 0 0                                {_range}\n" +
+          $"  4    TEST      0 0 1                                {_range}\n" +
+          $"  5    JMP       0 4              ; to 10             {_range}\n" +
+          $"  6    GETGLOB   0 {_printValFunc}                                  {_range}\n" +
+          $"  7    LOADK     1 -1             ; 1                 {_range}\n" +
+          $"  8    CALL      0 1 0                                {_range}\n" +
+          $"  9    JMP       0 3              ; to 13             {_range}\n" +
+          $"  10   GETGLOB   0 {_printValFunc}                                  {_range}\n" +
+          $"  11   LOADK     1 -2             ; 2                 {_range}\n" +
+          $"  12   CALL      0 1 0                                {_range}\n" +
+          $"  13   HALT      1 0                                  {_range}\n"
+      ).Replace("\n", Environment.NewLine);
+      TestCompiler(program, expected, RunMode.Interactive);
+    }
+
+    [Fact]
     public void TestCompileWhile() {
       string sum = "sum";
       string i = "i";

--- a/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/VMTests.cs
@@ -281,6 +281,25 @@ print(a[1:3])
       output.Should().Be(expectedOutput);
     }
 
+    [Fact]
+    public void TestExtraIfWithComparisonAndExpression() {
+      string source = @"
+def is_even(n):
+  return n % 2 == 0
+
+for n in range(10):
+  if n < 5 and is_even(n):
+    print(n)
+";
+      (string output, VisualizerHelper _) = Run(Parse(source), Array.Empty<Type>());
+      var expectedOutput = (
+        $"0\n" +
+        $"2\n" +
+        $"4\n"
+      ).Replace("\n", Environment.NewLine);
+      output.Should().Be(expectedOutput);
+    }
+
     private static (string, VisualizerHelper) Run(Statement program,
                                                   IReadOnlyList<Type> eventTypes) {
       var vc = new VisualizerCenter(() => new VMProxy(SeedXLanguage.SeedPython, null));


### PR DESCRIPTION
Fix #159 

Support following code now:
```python
def is_even(n):
  return n % 2 == 0


for n in range(10):
  if n < 5 and is_even(n):
    print(n)
```