### PR TITLE
Change field name from Value to RValue for assignment events

### DIFF
--- a/csharp/src/SeedLang.Shell/VisualizerManager.cs
+++ b/csharp/src/SeedLang.Shell/VisualizerManager.cs
@@ -123,7 +123,7 @@ namespace SeedLang.Shell {
       Console.ForegroundColor = ConsoleColor.Black;
       switch (e) {
         case Event.Assignment ae:
-          Console.Write($"Assign: {ae.Target} = {ae.Value}");
+          Console.Write($"Assign: {ae.Target} = {ae.RValue}");
           break;
         case Event.Binary be: {
             var op = _binaryOperatorStrings[be.Op];

--- a/csharp/src/SeedLang/Visualization/Events.cs
+++ b/csharp/src/SeedLang/Visualization/Events.cs
@@ -32,15 +32,15 @@ namespace SeedLang.Visualization {
     // containers.
     public class Assignment : AbstractEvent {
       public LValue Target { get; }
-      public RValue Value { get; }
+      public RValue RValue { get; }
 
-      public Assignment(LValue target, RValue value, TextRange range) : base(range) {
+      public Assignment(LValue target, RValue rValue, TextRange range) : base(range) {
         Target = target;
-        Value = value;
+        RValue = rValue;
       }
 
       public override string ToString() {
-        return $"{Range} {Target} = {Value}";
+        return $"{Range} {Target} = {RValue}";
       }
     }
 


### PR DESCRIPTION
Fix #217 

The client could access the value of assignment events by:

```csharp
double number = assignment.RValue.Value.AsNumber();
```