### PR TITLE
Support indention for the Func* visualizers

### DIFF
--- a/csharp/src/SeedLang.Shell/Executor.cs
+++ b/csharp/src/SeedLang.Shell/Executor.cs
@@ -76,6 +76,7 @@ namespace SeedLang.Shell {
     }
 
     private static void RunSource(Engine engine, SourceCode source, RunType runType) {
+      VisualizerManager.ResetState();
       var collection = new DiagnosticCollection();
       if (engine.Compile(source.Source, "", collection)) {
         source.WriteSourceWithTokens(engine.SemanticTokens);

--- a/csharp/src/SeedLang.Shell/Program.cs
+++ b/csharp/src/SeedLang.Shell/Program.cs
@@ -36,6 +36,10 @@ namespace SeedLang.Shell {
                          "that start with \"Func\".")]
       public IEnumerable<string> Visualizers { get; set; }
 
+      [Option("verbose", Required = false, Default = false,
+        HelpText = "Print visualization info in verbose mode.")]
+      public bool Verbose { get; set; }
+
       [Option('f', "file", Required = false, Default = null,
               HelpText = "Path of the file to be executed.")]
       public string Filename { get; set; }
@@ -52,7 +56,7 @@ namespace SeedLang.Shell {
         Console.WriteLine(helpText.Heading);
         Console.WriteLine(helpText.Copyright);
         Console.WriteLine();
-        var visualizers = VisualizerManager.CreateVisualizers(options.Visualizers);
+        var visualizers = VisualizerManager.CreateVisualizers(options.Visualizers, options.Verbose);
         Console.WriteLine($"Enabled Visualizers: {string.Join(", ", visualizers)}");
         Console.WriteLine();
         Run(options);

--- a/example_scripts/seedpython/hanoi.py
+++ b/example_scripts/seedpython/hanoi.py
@@ -3,7 +3,7 @@ def move(n, source, target, auxiliary):
         return
     move(n - 1, source, auxiliary, target)
     print('Tower ' + source + ' -> Tower ' + target)
-    move(n-1, auxiliary, target, source)
+    move(n - 1, auxiliary, target, source)
 
 
 num = 3

--- a/example_scripts/seedpython/hanoi.py
+++ b/example_scripts/seedpython/hanoi.py
@@ -1,0 +1,10 @@
+def move(n, source, target, auxiliary):
+    if n <= 0:
+        return
+    move(n - 1, source, auxiliary, target)
+    print('Tower ' + source + ' -> Tower ' + target)
+    move(n-1, auxiliary, target, source)
+
+
+num = 3
+move(num, 'A', 'B', 'C')


### PR DESCRIPTION
Add indention to SeedLang.Shell for the FuncCalled and FuncReturend visualizers, so that the function call stack in the runtime can be displayed clearly.

For example, use SeedLang.Shell to show the call stack of the Tower of Hanoi algorithm:

```shell
dotnet run --project src/SeedLang.Shell -- -f ../example_scripts/seedpython/hanoi.py -v "Func*"
SeedLang.Shell 0.2.1-preview20220728155708
Copyright 2021-2022 The SeedV Lab.

Enabled Visualizers: FuncCalled, FuncReturned

---------- Source ----------
1     def move(n, source, target, auxiliary):
2         if n <= 0:
3             return
4         move(n - 1, source, auxiliary, target)
5         print('Tower ' + source + ' -> Tower ' + target)
6         move(n-1, auxiliary, target, source)
7     
8     
9     num = 3
10    move(num, 'A', 'B', 'C')

---------- Run ----------
FuncCalled: move 3, 'A', 'B', 'C'
  FuncCalled: move 2, 'A', 'C', 'B'
    FuncCalled: move 1, 'A', 'B', 'C'
      FuncCalled: move 0, 'A', 'C', 'B'
      FuncReturned: move None
      FuncCalled: print 'Tower A -> Tower B'
Tower A -> Tower B
      FuncReturned: print None
      FuncCalled: move 0, 'C', 'B', 'A'
      FuncReturned: move None
    FuncReturned: move None
    FuncCalled: print 'Tower A -> Tower C'
Tower A -> Tower C
    FuncReturned: print None
    FuncCalled: move 1, 'B', 'C', 'A'
      FuncCalled: move 0, 'B', 'A', 'C'
      FuncReturned: move None
      FuncCalled: print 'Tower B -> Tower C'
Tower B -> Tower C
      FuncReturned: print None
      FuncCalled: move 0, 'A', 'C', 'B'
      FuncReturned: move None
    FuncReturned: move None
  FuncReturned: move None
  FuncCalled: print 'Tower A -> Tower B'
Tower A -> Tower B
  FuncReturned: print None
  FuncCalled: move 2, 'C', 'B', 'A'
    FuncCalled: move 1, 'C', 'A', 'B'
      FuncCalled: move 0, 'C', 'B', 'A'
      FuncReturned: move None
      FuncCalled: print 'Tower C -> Tower A'
Tower C -> Tower A
      FuncReturned: print None
      FuncCalled: move 0, 'B', 'A', 'C'
      FuncReturned: move None
    FuncReturned: move None
    FuncCalled: print 'Tower C -> Tower B'
Tower C -> Tower B
    FuncReturned: print None
    FuncCalled: move 1, 'A', 'B', 'C'
      FuncCalled: move 0, 'A', 'C', 'B'
      FuncReturned: move None
      FuncCalled: print 'Tower A -> Tower B'
Tower A -> Tower B
      FuncReturned: print None
      FuncCalled: move 0, 'C', 'B', 'A'
      FuncReturned: move None
    FuncReturned: move None
  FuncReturned: move None
FuncReturned: move None

```

