### PR TITLE
Support localized messages

### DIFF
--- a/csharp/src/SeedLang/Common/LocalizedMessages.cs
+++ b/csharp/src/SeedLang/Common/LocalizedMessages.cs
@@ -17,18 +17,13 @@ using System.Collections.Generic;
 using System.Globalization;
 
 namespace SeedLang.Common {
-
   // A singleton class to retrieve the localized strings of SeedLang messages.
   //
   // Compared to .Net's ResourceManager and Unity's Localization package, this implementation is
   // simpler and more straightforward. Hence it can be used in different hosting environments
   // without redefining localized strings.
   internal sealed class LocalizedMessages {
-    public static LocalizedMessages Instance {
-      get {
-        return _instance.Value;
-      }
-    }
+    public static LocalizedMessages Instance => _instance.Value;
 
     private static readonly Lazy<LocalizedMessages> _instance =
         new Lazy<LocalizedMessages>(() => new LocalizedMessages());
@@ -58,6 +53,8 @@ namespace SeedLang.Common {
             ["en"] = "Missing token. Found token: {0}. Expected token: {1}",
             ["zh-CN"] = "缺少 token. 遇到的 token: {0}. 期望的 token: {1}",
           },
+
+          // TODO: localize all other message strings.
         };
 
     private readonly Dictionary<(Message message, int LCID), string> _index =
@@ -73,8 +70,9 @@ namespace SeedLang.Common {
           // at all.
           return null;
         } else {
-          // In case "pl-PT" is not defined, its parent locale, "pl", will be used as a fallback. If
-          // "pl" is not defined, CultureInfo.InvariantCulture will be used as the final fallback.
+          // In case "pt-PT" is not defined, its parent locale, "pt", will be used as a fallback.
+          // And if "pt" is not defined, CultureInfo.InvariantCulture will be used as the final
+          // fallback.
           culture = culture.Parent;
         }
       }

--- a/csharp/src/SeedLang/Common/LocalizedMessages.cs
+++ b/csharp/src/SeedLang/Common/LocalizedMessages.cs
@@ -1,0 +1,99 @@
+// Copyright 2021-2022 The SeedV Lab.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace SeedLang.Common {
+
+  // A singleton class to retrieve the localized strings of SeedLang messages.
+  //
+  // Compared to .Net's ResourceManager and Unity's Localization package, this implementation is
+  // simpler and more straightforward. Hence it can be used in different hosting environments
+  // without redefining localized strings.
+  internal sealed class LocalizedMessages {
+    public static LocalizedMessages Instance {
+      get {
+        return _instance.Value;
+      }
+    }
+
+    private static readonly Lazy<LocalizedMessages> _instance =
+        new Lazy<LocalizedMessages>(() => new LocalizedMessages());
+
+    // The locale that is used as the final fallback.
+    private const string _defaultLocale = "en";
+
+    // Defines localized messages here. Each message must contain a string of _defaultLocale.
+    private static readonly Dictionary<Message, Dictionary<string, string>> _messages =
+        new Dictionary<Message, Dictionary<string, string>>() {
+          [Message.Okay] = new Dictionary<string, string>() {
+            ["en"] = "Okay",
+            ["zh-CN"] = "好",
+          },
+
+          [Message.Yes] = new Dictionary<string, string>() {
+            ["en"] = "Yes",
+            ["zh-CN"] = "是",
+          },
+
+          [Message.No] = new Dictionary<string, string>() {
+            ["en"] = "No",
+            ["zh-CN"] = "否",
+          },
+
+          [Message.SyntaxErrorMissingToken2] = new Dictionary<string, string>() {
+            ["en"] = "Missing token. Found token: {0}. Expected token: {1}",
+            ["zh-CN"] = "缺少 token. 遇到的 token: {0}. 期望的 token: {1}",
+          },
+        };
+
+    private readonly Dictionary<(Message message, int LCID), string> _index =
+        new Dictionary<(Message message, int LCID), string>();
+
+    public string Get(Message message, CultureInfo culture) {
+      while (true) {
+        if (_index.TryGetValue((message, culture.LCID), out string result)) {
+          return result;
+        } else if (culture == CultureInfo.InvariantCulture) {
+          // Every message defined in _messages has a CultureInfo.InvariantCulture entry. Thus the
+          // lack of the CultureInfo.InvariantCulture entry implies that the message is not defined
+          // at all.
+          return null;
+        } else {
+          // In case "pl-PT" is not defined, its parent locale, "pl", will be used as a fallback. If
+          // "pl" is not defined, CultureInfo.InvariantCulture will be used as the final fallback.
+          culture = culture.Parent;
+        }
+      }
+    }
+
+    private LocalizedMessages() {
+      // Initializes the index table.
+      foreach (var message in _messages.Keys) {
+        foreach (var locale in _messages[message].Keys) {
+          var culture = new CultureInfo(locale);
+          var localizedString = _messages[message][locale];
+          _index[(message, culture.LCID)] = localizedString;
+          if (locale == _defaultLocale) {
+            // Uses CultureInfo.InvariantCulture as the final fallback entry, which holds the
+            // localized string of _defaultLocale.
+            _index[(message, CultureInfo.InvariantCulture.LCID)] = localizedString;
+          }
+        }
+      }
+    }
+  }
+}

--- a/csharp/src/SeedLang/Common/Message.cs
+++ b/csharp/src/SeedLang/Common/Message.cs
@@ -13,35 +13,27 @@
 // limitations under the License.
 
 using System;
+using System.Globalization;
 using System.Text;
 
 namespace SeedLang.Common {
   // The ID list of string messages.
   //
-  // SeedLang uses an intermediate <MessageId, MessageString> system to separate the client usages
-  // and the underlying implementation of localized messages.
+  // The trailing decimal digit of the message ID indicates the number of the required arguments,
+  // ranging from 0 to 9.
   //
-  // When developers come to a string which might be seen by the users, they simply add a new
-  // PascalCased ID to the following Enum. The last digit of the ID indicates the number of
-  // arguments that the string formatter requires.
-  //
-  // During the development stage, developers use code patterns
+  // To retrieve the raw localized string with argument placeholders such as "{0}":
   //
   //    Message.SomeId.Get()
+  //    Message.SomeId.Get(culture)
+  //
+  // To localizes and formats a message with given arguments:
   //
   //    Message.SomeIdWithThreeArguments3.Format(arg1, arg2, arg3)
+  //    Message.SomeIdWithThreeArguments3.Format(culture, arg1, arg2, arg3)
   //
-  // to fill a string message in their code. The default behavior of the MessageHelper utility
-  // generates a mock string according to the message ID. This is good enough for development and
-  // debugging.
-  //
-  // Once the message strings are translated and served by an underlying implementation, such as
-  // .Net's default ResourceManager, the MessageHelper utility will be updated to hide the
-  // implementation details so that the client code need no change to adapt a real localization
-  // mechanism.
-  //
-  // With this intermediate layer, we will be able to introduce lightweight or cross-platform
-  // localization solutions other than .Net's default ResourceManager when necessary.
+  // Both methods accept a CultureInfo object that specifies the expected locale. If the culture
+  // parameter is omitted, the current CultureInfo object will be used.
   public enum Message {
     // Example message strings.
 
@@ -87,35 +79,39 @@ namespace SeedLang.Common {
   }
 
   public static class MessageHelper {
-    // Returns the original message string without formatting it. The required arguments will be
-    // rendered as {n} inside the string. The trailing decimal digit of the message ID indicates the
-    // number of the required arguments, ranging from 0 to 9.
+    // Returns the raw message string without formatting it, using the current CultureInfo. The
+    // required arguments will be rendered as placeholders, in the "{n}" format.
     public static string Get(this Message message) {
-      // TODO: Support the real localization system once the strings are localized.
-      (string name, int requiredArgumentNumber) = Parse(message);
-      var sb = new StringBuilder(name);
-      for (var i = 0; i < requiredArgumentNumber; i++) {
-        sb.AppendFormat(" {{{0}}}", i);
-      }
-      return sb.ToString();
+      return Get(message, CultureInfo.CurrentCulture);
     }
 
-    // Formats the message string with the input arguments. The trailing decimal digit of the
-    // message ID indicates the number of the required arguments, ranging from 0 to 9.
+    // Returns the raw message string without formatting it, using the specified CultureInfo.
+    public static string Get(this Message message, CultureInfo culture) {
+      var ret = LocalizedMessages.Instance.Get(message, culture);
+      if (ret is null) {
+        (string name, int requiredArgumentNumber) = Parse(message);
+        var sb = new StringBuilder(name);
+        for (var i = 0; i < requiredArgumentNumber; i++) {
+          sb.AppendFormat(" {{{0}}}", i);
+        }
+        return sb.ToString();
+      } else {
+        return ret;
+      }
+    }
+
+    // Formats the message string with the input arguments, using the current CultureInfo
     public static string Format(this Message message, params string[] arguments) {
-      // TODO: Support the real localization system once the strings are localized.
-      (string name, int requiredArgumentNumber) = Parse(message);
-      if (requiredArgumentNumber > arguments.Length) {
-        throw new ArgumentException($"Not enough arguments to format the string message: {name}.");
-      }
-      var sb = new StringBuilder(name);
-      for (var i = 0; i < requiredArgumentNumber; i++) {
-        sb.AppendFormat(" {0}", arguments[i]);
-      }
-      return sb.ToString();
+      return string.Format(Get(message), arguments);
     }
 
-    static (string name, int requiredArgumentNumber) Parse(Message message) {
+    // Formats the message string with the input arguments, using the specified CultureInfo.
+    public static string Format(this Message message, CultureInfo culture,
+                                params string[] arguments) {
+      return string.Format(Get(message, culture), arguments);
+    }
+
+    private static (string name, int requiredArgumentNumber) Parse(Message message) {
       string name = Enum.GetName(typeof(Message), message);
       if (name.Length <= 0) {
         return ("", 0);

--- a/csharp/src/SeedLang/Common/Message.cs
+++ b/csharp/src/SeedLang/Common/Message.cs
@@ -89,6 +89,8 @@ namespace SeedLang.Common {
     public static string Get(this Message message, CultureInfo culture) {
       var ret = LocalizedMessages.Instance.Get(message, culture);
       if (ret is null) {
+        // If the message has not been localized, returns the enum name with its argument
+        // placeholders as the result.
         (string name, int requiredArgumentNumber) = Parse(message);
         var sb = new StringBuilder(name);
         for (var i = 0; i < requiredArgumentNumber; i++) {

--- a/csharp/tests/SeedLang.Tests/Common/MessageTests.cs
+++ b/csharp/tests/SeedLang.Tests/Common/MessageTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Globalization;
 using Xunit;
 
 namespace SeedLang.Common.Tests {
@@ -33,9 +34,43 @@ namespace SeedLang.Common.Tests {
       Assert.Equal("Yes", Message.Yes.Format("Unused Argument"));
       Assert.Equal("ExampleMessageWithOneArgument Hello",
                    Message.ExampleMessageWithOneArgument1.Format("Hello"));
-      Assert.Throws<ArgumentException>(() => Message.ExampleMessageWithOneArgument1.Format());
+      Assert.Throws<FormatException>(() => Message.ExampleMessageWithOneArgument1.Format());
       Assert.Equal("ExampleMessageWithTwoArguments Hello 3.14",
                    Message.ExampleMessageWithTwoArguments2.Format("Hello", (3.14).ToString()));
+    }
+
+    [Theory]
+    [InlineData(Message.Okay, "en", "Okay")]
+    [InlineData(Message.Okay, "zh-CN", "好")]
+    [InlineData(Message.Okay, "en-US", "Okay")]  // "en-US" is able to fall back to "en".
+    [InlineData(Message.Okay, "", "Okay")]       // Empty locale. Falls back to "en".
+    [InlineData(Message.Okay, "ab", "Okay")]     // Very rare locale. Falls back to "en".
+    public void TestLocalizedMessages(Message message, string locale, string localizedString) {
+      Assert.Equal(localizedString, message.Format(new CultureInfo(locale)));
+    }
+
+    [Theory]
+    [InlineData(Message.SyntaxErrorMissingToken2,
+                "en",
+                "Missing token. Found token: X. Expected token: Y",
+                "X",
+                "Y")]
+    [InlineData(Message.SyntaxErrorMissingToken2,
+                "en-US",
+                "Missing token. Found token: X. Expected token: Y",
+                "X",
+                "Y")]
+    [InlineData(Message.SyntaxErrorMissingToken2,
+                "zh-CN",
+                "缺少 token. 遇到的 token: X. 期望的 token: Y",
+                "X",
+                "Y")]
+    public void TestLocalizedMessagesWithTwoArguments(Message message,
+                                                       string locale,
+                                                       string localizedString,
+                                                       string arg1,
+                                                       string arg2) {
+      Assert.Equal(localizedString, message.Format(new CultureInfo(locale), arg1, arg2));
     }
   }
 }

--- a/csharp/tests/SeedLang.Tests/Common/MessageTests.cs
+++ b/csharp/tests/SeedLang.Tests/Common/MessageTests.cs
@@ -72,5 +72,18 @@ namespace SeedLang.Common.Tests {
                                                        string arg2) {
       Assert.Equal(localizedString, message.Format(new CultureInfo(locale), arg1, arg2));
     }
+
+    [Fact]
+    public void TestChangeCurrentCulture() {
+      Assert.Equal("Yes", Message.Yes.Format());
+      CultureInfo.CurrentCulture = new CultureInfo("zh-CN");
+      Assert.Equal("是", Message.Yes.Format());
+      CultureInfo.CurrentCulture = new CultureInfo("en-US");
+      Assert.Equal("Yes", Message.Yes.Format());
+      CultureInfo.CurrentCulture = new CultureInfo("en");
+      Assert.Equal("Yes", Message.Yes.Format());
+      CultureInfo.CurrentCulture = new CultureInfo("ab");
+      Assert.Equal("Yes", Message.Yes.Format());
+    }
   }
 }

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonErrorTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonErrorTests.cs
@@ -106,7 +106,7 @@ namespace SeedLang.X.Tests {
 
     [InlineData("while True",
                 new string[] {
-                  @"SyntaxErrorMissingToken '\n' ':'",
+                  @"Missing token. Found token: '\n'. Expected token: ':'",
                   "SyntaxErrorInputMismatch '<EOF>' INDENT",
                 },
 


### PR DESCRIPTION
With this PR, SeedLang.Shell outputs error messages in the following way (only SyntaxErrorMissingToken2 is localized in this PR):

```
>>> def a()
---------- Source ----------
1     def a()

---------- Compile Error ----------
1     def a()
: 20220809205400297 Fatal (SeedLang.X) <> [Ln 1, Col 7 - Ln 1, Col 7] 29: Missing token. Found token: '\n'. Expected token: ':'
: 20220809205400299 Fatal (SeedLang.X) <> [Ln 2, Col 0 - Ln 2, Col -1] 28: SyntaxErrorInputMismatch '<EOF>' INDENT
```

After setting the current locale in SeedLang.Shell with

```
CultureInfo.CurrentCulture = new CultureInfo("zh-CN");
```

SeedLang.Shell outputs Chinese info like below:

```
>>> def a()
---------- Source ----------
1     def a()

---------- Compile Error ----------
1     def a()
: 20220809210408162 Fatal (SeedLang.X) <> [Ln 1, Col 7 - Ln 1, Col 7] 29: 缺少 token. 遇到的 token: '\n'. 期望的 token: ':'
: 20220809210408164 Fatal (SeedLang.X) <> [Ln 2, Col 0 - Ln 2, Col -1] 28: SyntaxErrorInputMismatch '<EOF>' INDENT
```