### PR TITLE
Fix broken relative links

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,10 +1,9 @@
 title: SeedLang
 email: codingpotato@gmail.com
 description: >- # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
-baseurl: "/"
+  SeedLang is an embeddable and visualizable scripting engine for .Net and
+  Unity. Here is the documentation site of SeedLang.
+baseurl: "/SeedLang"
 url: "https://seedv.github.io"
 twitter_username: jekyllrb
 github_username: SeedV

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -47,8 +47,8 @@ move(num, 'A', 'B', 'C')
 See [SeedPython Example
 Scripts](https://github.com/SeedV/SeedLang/tree/main/example_scripts/seedpython).
 
-See [SeedPython]({% link seedpython.md %}) for more details of the
-language.
+See [SeedPython]({{ site.baseurl }}{% link seedpython.md %}) for more details of
+the language.
 
 ## Install Microsoft .NET
 
@@ -187,8 +187,8 @@ visualizer names include:
 - **VTagEntered**: triggered when a V-Tag scope is entered.
 - **VTagExited**: triggered when a V-Tag scope is exited.
 
-See [SeedLang Visualization]({% link visualization.md %}) for more info about
-the visualization API and the definition of V-Tags.
+See [SeedLang Visualization]({{ site.baseurl }}{% link visualization.md %}) for
+more info about the visualization API and the definition of V-Tags.
 
 You can use the wildcard `*` to turn on multiple visualizers like below:
 
@@ -290,8 +290,10 @@ Please check the `README.md` file of the `SeedLangExamples` for more info.
 
 ### Embedding SeedLang in .Net applications
 
-Please read [Embedding SeedLang in .Net]({% link dotnet_embedding.md %}).
+Please read [Embedding SeedLang in .Net]({{ site.baseurl }}{% link
+dotnet_embedding.md %}).
 
 ### Embedding SeedLang in Unity games
 
-Please read [Embedding SeedLang in Unity]({% link unity_embedding.md %}).
+Please read [Embedding SeedLang in Unity]({{ site.baseurl }}{% link
+unity_embedding.md %}).

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,4 +47,4 @@ for more example applications and games.
 ## Getting Started
 
 For the usage and the examples of SeedLang, see [Getting
-Started]({% link getting_started.md %}).
+Started]({{ site.baseurl }}{% link getting_started.md %}).


### PR DESCRIPTION
Relative links to *.md are broken on the GitHub pages site https://seedv.github.io/SeedLang/ (those links worked on local server instead)

I tried to fix broken links with the following changes:

1. Add `baseurl: "/SeedLang"` to the jekyall config file.
2. Prepend `{{ site.baseurl }}` to each relative *.md link.

A local test proves the change works for relative links. But I am not quite sure this will work well on GitHub pages - depending on the push result after this PR is merged.
